### PR TITLE
Improve web automation reliability

### DIFF
--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -21,6 +21,11 @@ app = Flask(__name__)
 log = logging.getLogger("auto")
 log.setLevel(logging.INFO)
 
+# 各 Playwright アクションのデフォルトタイムアウト(ms)
+# Google Flights など動的なページでも余裕を持って待機できるよう
+# やや長めに設定する
+ACTION_TIMEOUT = 20000
+
 # 一貫したイベントループを確保する
 LOOP = asyncio.new_event_loop()
 asyncio.set_event_loop(LOOP)
@@ -120,7 +125,7 @@ async def normalize(a: Dict) -> Dict:
         a["target"] = a["text"]
     return a
 
-async def safe_click_by_text(page, txt: str):
+async def safe_click_by_text(page, txt: str, timeout: int = ACTION_TIMEOUT):
     """
     Playwright strict-mode で複数マッチした場合の 500 を防ぐ。
     1) リンク (<a>) を role='link', exact=True で取得しクリック
@@ -130,17 +135,24 @@ async def safe_click_by_text(page, txt: str):
     # 1) リンク (exact)
     link = page.get_by_role("link", name=txt, exact=True)
     if await link.count():
-        await link.first.click()
+        await link.first.wait_for(state="visible", timeout=timeout)
+        await link.first.scroll_into_view_if_needed(timeout=timeout)
+        await link.first.click(timeout=timeout)
         return
 
     # 2) exact=True テキスト
     exact_loc = page.get_by_text(txt, exact=True)
     if await exact_loc.count():
-        await exact_loc.first.click()
+        await exact_loc.first.wait_for(state="visible", timeout=timeout)
+        await exact_loc.first.scroll_into_view_if_needed(timeout=timeout)
+        await exact_loc.first.click(timeout=timeout)
         return
 
     # 3) 非 strict (first match)
-    await page.get_by_text(txt).first.click()
+    last = page.get_by_text(txt).first
+    await last.wait_for(state="visible", timeout=timeout)
+    await last.scroll_into_view_if_needed(timeout=timeout)
+    await last.click(timeout=timeout)
 
 async def run_actions(raw: List[Dict]) -> str:
     """
@@ -158,16 +170,34 @@ async def run_actions(raw: List[Dict]) -> str:
     async def exec_one(act):
         match act["action"]:
             case "navigate":
-                await GLOBAL_PAGE.goto(act["target"])
+                await GLOBAL_PAGE.goto(
+                    act["target"],
+                    timeout=ACTION_TIMEOUT,
+                    wait_until="load",
+                )
             case "click":
                 if sel := act.get("target"):
-                    await GLOBAL_PAGE.locator(sel).first.click()
+                    loc = GLOBAL_PAGE.locator(sel).first
+                    await loc.wait_for(state="visible", timeout=ACTION_TIMEOUT)
+                    await loc.scroll_into_view_if_needed(timeout=ACTION_TIMEOUT)
+                    await loc.click(timeout=ACTION_TIMEOUT)
                 elif txt := act.get("text"):
-                    await safe_click_by_text(GLOBAL_PAGE, txt)
+                    await safe_click_by_text(
+                        GLOBAL_PAGE,
+                        txt,
+                        timeout=ACTION_TIMEOUT,
+                    )
             case "click_text":
-                await safe_click_by_text(GLOBAL_PAGE, act["target"])
+                await safe_click_by_text(
+                    GLOBAL_PAGE,
+                    act["target"],
+                    timeout=ACTION_TIMEOUT,
+                )
             case "type":
-                await GLOBAL_PAGE.fill(act["target"], act.get("value", ""))
+                loc = GLOBAL_PAGE.locator(act["target"]).first
+                await loc.wait_for(state="visible", timeout=ACTION_TIMEOUT)
+                await loc.scroll_into_view_if_needed(timeout=ACTION_TIMEOUT)
+                await loc.fill(act.get("value", ""), timeout=ACTION_TIMEOUT)
             case "wait":
                 await GLOBAL_PAGE.wait_for_timeout(int(act.get("ms", 500)))
             case "scroll":

--- a/web/static/chat_integration.js
+++ b/web/static/chat_integration.js
@@ -37,10 +37,10 @@ document.addEventListener("DOMContentLoaded", () => {
           notice.classList.add("system-message");
           notice.textContent = `未完了タスクを再開します: 「${cmd}」`;
           chatArea.appendChild(notice);
-          /* 変更: skipFirst=false → 最初の説明も UI に表示 */
+          /* 未完了タスクをモデル設定で再開する */
           const model = modelSelect ? modelSelect.value : "gemini";
           if (typeof window.executeTask === "function") {
-            await window.executeTask(cmd, false, model);
+            await window.executeTask(cmd, model);
           } else {
             console.error("executeTask function not found.");
           }
@@ -80,29 +80,17 @@ document.addEventListener("DOMContentLoaded", () => {
     const b = document.createElement("p");
     b.classList.add("bot-message");
     b.textContent = "AI が応答中...";
-    const spin = document.createElement("span");   // 追加
-    spin.classList.add("spinner");                 // 追加
-    b.appendChild(spin);                           // 追加
+    const spin = document.createElement("span");
+    spin.classList.add("spinner");
+    b.appendChild(spin);
     chatArea.appendChild(b);
     chatArea.scrollTop = chatArea.scrollHeight;
 
     try {
-      /* プレビュー用に LLM 呼び出し（/execute） */
-      const pageSrc = await fetchVncHtml();
-      const model   = modelSelect ? modelSelect.value : "gemini";
-      const preview = await sendCommand(text, pageSrc, model);
-
-      /* 変更: チャット欄には explanation のみを表示（JSONプレビューを削除） */
-      b.textContent = preview.explanation || "(説明がありません)";
-
-      /* DevTools Console に raw を 1 回だけ表示 */
-      if (preview.raw) console.log("LLM raw output:\n", preview.raw);
-
-      /* ----- マルチターン実行開始 -----
-         skipFirst = true: 1st ターンは既に UI に表示済みなので
-         2 ターン目以降だけ追加表示する */
+      const model = modelSelect ? modelSelect.value : "gemini";
+      /* ----- マルチターン実行開始 ----- */
       if (typeof window.executeTask === "function") {
-        await window.executeTask(text, true, model);
+        await window.executeTask(text, model, b);
       } else {
         console.error("executeTask function not found.");
       }


### PR DESCRIPTION
## Summary
- increase default Playwright timeout and wait for elements before interacting
- scroll and wait in safe_click_by_text helper
- fix resume logic for unfinished tasks

## Testing
- `python -m py_compile vnc/automation_server.py web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684912bc06c883209b0603f6421c867f