### PR TITLE
Improve element indexing and prompts

### DIFF
--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -27,6 +27,14 @@ def execute_dsl(payload, timeout=120):
     except requests.Timeout:
         log.error("execute_dsl timeout")
         raise
+
+
+def get_elements() -> list:
+    """Get clickable/input elements with index info."""
+    try:
+        res = requests.get(f"{VNC_API}/elements", timeout=30)
+        res.raise_for_status()
+        return res.json()
     except Exception as e:
-        log.error("execute_dsl error: %s", e)
-        raise
+        log.error("get_elements error: %s", e)
+        return []

--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -6,11 +6,18 @@ log = logging.getLogger("controller")
 MAX_STEPS = int(os.getenv("MAX_STEPS", "10"))
 
 
-def build_prompt(cmd: str, page: str, hist, screenshot: bool = False) -> str:
+def build_prompt(cmd: str, page: str, hist, screenshot: bool = False, elements=None) -> str:
     """Return full system prompt for the LLM."""
     past_conv = "\n".join(f"U:{h['user']}\nA:{h['bot']['explanation']}" for h in hist)
 
     add_img = "現在の状況を把握するために、スクリーンショット画像も与えます。" if screenshot else ""
+    elem_lines = ""
+    if elements:
+        elem_lines = "\n".join(
+            f"[{e.get('index')}] <{e.get('tag')}> {e.get('text')} id={e.get('id')} class={e.get('class')}"
+            for e in elements
+        )
+
     system_prompt = (
     "あなたは、ブラウザタスクを自動化するために反復ループで動作するAIエージェントです。\n"
     "最終的な目標は、ユーザーに命令されたタスクを達成することです。\n\n"
@@ -178,6 +185,9 @@ def build_prompt(cmd: str, page: str, hist, screenshot: bool = False) -> str:
     ========================================================================
     """
     "\n"
+    "---- 操作候補要素一覧 (操作対象は番号で指定) ----\n"
+    f"{elem_lines}\n"
+    "--------------------------------\n"
     "---- 現在のページ HTML(一部) ----\n"
     f"{strip_html(page)}\n"
     "--------------------------------\n"

--- a/vnc/locator_utils.py
+++ b/vnc/locator_utils.py
@@ -46,6 +46,8 @@ class SmartLocator:
             if m:
                 role, name = m.groups()
                 return await self._try(self.page.get_by_role(role, name=name, exact=True))
+        if t.startswith("xpath="):
+            return await self._try(self.page.locator(t))
 
         # data-testid
         loc = await self._try(self.page.locator(f"[data-testid='{t}']"))
@@ -59,9 +61,19 @@ class SmartLocator:
         loc = await self._try(self.page.locator(f"input[placeholder='{t}']"))
         if loc:
             return loc
+        # label text followed by input element
+        loc = await self._try(self.page.locator(f"label:has-text('{t}') + input"))
+        if loc:
+            return loc
+        loc = await self._try(self.page.locator(f"xpath=//*[normalize-space(text())='{t}']/following::input[1]"))
+        if loc:
+            return loc
 
         # 可視テキスト
         loc = await self._try(self.page.get_by_text(t, exact=True))
+        if loc:
+            return loc
+        loc = await self._try(self.page.locator(f"xpath=//*[contains(normalize-space(text()), '{t}')][1]"))
         if loc:
             return loc
 

--- a/web/app.py
+++ b/web/app.py
@@ -6,7 +6,7 @@ from flask import Flask, request, jsonify, render_template, Response, send_from_
 
 # --------------- Agent modules -----------------------------------
 from agent.llm.client import call_llm
-from agent.browser.vnc import get_html as vnc_html, execute_dsl
+from agent.browser.vnc import get_html as vnc_html, execute_dsl, get_elements as vnc_elements
 from agent.controller.prompt import build_prompt
 from agent.utils.history import load_hist, save_hist
 from agent.utils.html import strip_html
@@ -65,7 +65,8 @@ def execute():
     shot  = data.get("screenshot")
     model = data.get("model", "gemini")
     hist  = load_hist()
-    prompt = build_prompt(cmd, strip_html(page), hist, bool(shot))
+    elements = vnc_elements()
+    prompt = build_prompt(cmd, strip_html(page), hist, bool(shot), elements)
     res   = call_llm(prompt, model, shot)
 
     hist.append({"user": cmd, "bot": res})


### PR DESCRIPTION
## Summary
- add `/elements` endpoint to list clickable elements
- expose `get_elements()` utility
- show element list in prompt builder
- fetch elements in web API
- extend SmartLocator heuristics

## Testing
- `python -m py_compile vnc/automation_server.py agent/browser/vnc.py agent/controller/prompt.py vnc/locator_utils.py >/tmp/py_compile.log`

------
https://chatgpt.com/codex/tasks/task_e_68634c03770c832096536bf5bf2debf6