### PR TITLE
Fix DOM tree error and reduce HTML usage

### DIFF
--- a/agent/browser/dom.py
+++ b/agent/browser/dom.py
@@ -34,3 +34,27 @@ class DOMElementNode:
             highlightIndex=data.get("highlightIndex"),
             children=children,
         )
+
+    def to_lines(self, depth: int = 0, max_lines: int = 200, _lines=None) -> List[str]:
+        """Return indented text representation of the DOM tree."""
+        if _lines is None:
+            _lines = []
+        if len(_lines) >= max_lines:
+            return _lines
+        indent = "  " * depth
+        if self.tagName == "#text":
+            if self.text and self.text.strip():
+                _lines.append(f"{indent}{self.text.strip()}")
+            return _lines
+        attr = " ".join(f"{k}={v}" for k, v in self.attributes.items() if v)
+        idx = f" [{self.highlightIndex}]" if self.highlightIndex is not None else ""
+        line = f"{indent}<{self.tagName}{(' ' + attr) if attr else ''}>{idx}"
+        _lines.append(line)
+        for ch in self.children:
+            if len(_lines) >= max_lines:
+                break
+            ch.to_lines(depth + 1, max_lines, _lines)
+        return _lines
+
+    def to_text(self, max_lines: int = 200) -> str:
+        return "\n".join(self.to_lines(max_lines=max_lines))

--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -14,16 +14,28 @@ def _collect_interactive(node: DOMElementNode, lst: list):
         _collect_interactive(ch, lst)
 
 
-def build_prompt(cmd: str, page: str, hist, screenshot: bool = False, elements: DOMElementNode | list | None = None) -> str:
+def build_prompt(
+    cmd: str,
+    page: str,
+    hist,
+    screenshot: bool = False,
+    elements: DOMElementNode | list | None = None,
+) -> str:
     """Return full system prompt for the LLM."""
     past_conv = "\n".join(f"U:{h['user']}\nA:{h['bot']['explanation']}" for h in hist)
 
-    add_img = "現在の状況を把握するために、スクリーンショット画像も与えます。" if screenshot else ""
+    add_img = (
+        "現在の状況を把握するために、スクリーンショット画像も与えます。"
+        if screenshot
+        else ""
+    )
     elem_lines = ""
+    dom_text = strip_html(page)
     if elements:
         nodes: list[DOMElementNode] = []
         if isinstance(elements, DOMElementNode):
             _collect_interactive(elements, nodes)
+            dom_text = elements.to_text()
         elif isinstance(elements, list):
             for n in elements:
                 if isinstance(n, DOMElementNode):
@@ -34,9 +46,9 @@ def build_prompt(cmd: str, page: str, hist, screenshot: bool = False, elements: 
         )
 
     system_prompt = (
-    "あなたは、ブラウザタスクを自動化するために反復ループで動作するAIエージェントです。\n"
-    "最終的な目標は、ユーザーに命令されたタスクを達成することです。\n\n"
-    """
+        "あなたは、ブラウザタスクを自動化するために反復ループで動作するAIエージェントです。\n"
+        "最終的な目標は、ユーザーに命令されたタスクを達成することです。\n\n"
+        """
     ** 基本的な思考プロセス**\n
     ** あなたは行動を決定する前に、必ず以下の思考プロセスを内部的に実行してください。**\n
     ** 1.  観察 (Observation): まず、現在のページのHTML情報やスクリーンショットを注意深く読み解きます。特に、直前の自分のアクションによってページがどのように変化したか（新しい要素は表示されたか、何かが消えたかなど）に注目します。**\n
@@ -44,14 +56,14 @@ def build_prompt(cmd: str, page: str, hist, screenshot: bool = False, elements: 
     ** 3.  行動決定 (Action Decision): 最後に、思考の結果として最も合理的だと判断したアクションをJSON形式で出力します。**\n
     ** **\n\n
     """
-    """あなたは以下のタスクに優れています: \n
+        """あなたは以下のタスクに優れています: \n
     1. 複雑なウェブサイトをナビゲートし、正確な情報を抽出する \n
     2. フォームの送信とインタラクティブなウェブアクションを自動化する \n
     3. 情報を収集して保存する \n
     4. ファイルシステムを効果的に使用して、コンテキストに何を保持するかを決定する\n
     5. エージェントループで効果的に操作する \n
     6. 多様なウェブタスクを効率的に実行する\n\n"""
-    """
+        """
     各ステップで、次の状態が表示されます。\n
     1. エージェント履歴: 以前のアクションとその結果を含む時系列のイベント ストリーム。これは部分的に省略される場合があります。\n
     2. ユーザー リクエスト: これは最終目的で、常に表示されます。\n
@@ -97,110 +109,96 @@ def build_prompt(cmd: str, page: str, hist, screenshot: bool = False, elements: 
         - ユーザーリクエストが最終的な目標です。ユーザーが明示的に手順を指定した場合、その手順は常に最優先されます。\n
         - ユーザーがページ内の特定のテキスト情報を求めている場合は、その情報を抽出して説明に含めて返すこと。\n\n
     """
-    "|目的|\n"
-    "ユーザーの自然言語命令を受け取り、Playwright 互換の DSL(JSON) でブラウザ操作手順を生成します。\n"
-    "まず **現在表示されているページ(HTML ソースを渡します)** を必ず確認し、"
-    "さらに **ユーザーがページ内の具体的なテキスト情報を求めている場合は、その情報を抽出して説明に含めて返す** こと。\n"
-    "（例: 『開催概要を教えて』→ ページにある開催概要を説明文に貼り付ける）\n"
-    "\n"
-    "|出力フォーマット|\n"
-    "1 行目〜複数行 : 取得した情報や操作意図を日本語で説明。\n"
-    "    ユーザーが求めたページ内情報があれば **ここに要約または全文を含める**。\n"
-    "    80 文字制限は撤廃して良いが、最長 300 文字程度に収める。\n"
-    "その後に ```json フェンス内で DSL を出力。\n"
-    "\n"
-    "```json の中身は以下のフォーマット:\n"
-    "{\n"
-    '  "actions": [ <action_object> , ... ],\n'
-    '  "complete": true | false               # true ならタスク完了, false なら未完了で続行\n'
-    "}\n"
-    "\n"
-    "<action_object> は次のいずれか:\n"
-    "  { \"action\": \"navigate\",       \"target\": \"https://example.com\" }\n"
-    "  { \"action\": \"click\",          \"target\": \"css=button.submit\" }\n"
-    "  { \"action\": \"click_text\",     \"text\":   \"次へ\" }\n"
-    "  { \"action\": \"type\",           \"target\": \"css=input[name=q]\", \"value\": \"検索ワード\" }\n"
-    "  { \"action\": \"wait\",           \"ms\": 1000 }\n"
-    "  { \"action\": \"scroll\",         \"target\": \"css=div.list\", \"direction\": \"down\", \"amount\": 400 }\n"
-    "  { \"action\": \"go_back\" }\n"
-    "  { \"action\": \"go_forward\" }\n"
-    "  { \"action\": \"hover\",          \"target\": \"css=div.menu\" }\n"
-    "  { \"action\": \"select_option\",   \"target\": \"css=select\", \"value\": \"option1\" }\n"
-    "  { \"action\": \"press_key\",      \"key\": \"Enter\", \"target\": \"css=input\" }\n"
-    "  { \"action\": \"wait_for_selector\", \"target\": \"css=button.ok\", \"ms\": 3000 }\n"
-    "  { \"action\": \"extract_text\",    \"target\": \"css=div.content\" }\n\n\n"
-    
-    "\n\n"
-    "|ルール|\n"
-    "1. 現ページで表示されている要素のみ操作してよい。ページ遷移後の要素の操作は、次のステップで生成しなくてはいけない。つまりページ遷移が必要かつ、複数のアクションがあった場合には、ページ遷移が最後のアクションである必要がある。\n"
-    "2. 与えられた情報にある要素のみ操作してよい。要素名を予想してアクションを生成することはしてはいけない。\n"
-    "3. 現ページで目的達成できる場合は `actions` を **空配列** で返し、`complete:true`。\n"
-    "4. `click` はCSSセレクタで指定します。**非表示要素(`aria-hidden='true'`など)を避け、ユニークな属性(id, name, data-testidなど)を優先してください。**\n"
-    "5. `click_text` は可視テキストで指定します。\n"
-    "6. 失敗しやすい操作には `wait` を挿入し、安定化を図ること。\n"
-    "7. 類似要素が複数ある場合は `:nth-of-type()` や `:has-text()` などで特定性を高める。\n"
-    "8. 一度に大量の操作を出さず、状況確認が必要な場合は `complete:false` とし段階的に進める。\n"
-    "9. 一度に有効な複数の操作を出す場合には、各アクションの間に１秒の待機を設ける\n"
-    "10. **ユーザーがページ内テキストを要求している場合**:\n"
-    "    - `navigate` や `click` を行わずとも情報が取れるなら `actions` は空。\n"
-    "    - 説明部にページから抽出したテキストを含める（長文は冒頭 200 文字＋\"...\"）。\n"
-    f"11. 最大 {MAX_STEPS} ステップ以内にタスクを完了できない場合は `complete:true` で終了してください。\n"
-    "\n"
-
-    "Python で利用できるアクションヘルパー関数:\n"
-    "#click: 指定したターゲットをクリックするアクション\n"
-    "  def click(target: str) -> Dict:\n"
-    "      return {\"action\": \"click\", \"target\": target}\n"
-    
-    "#click_text: 指定したテキストを持つ要素をクリックするアクション\n"
-    "  def click_text(text: str) -> Dict:\n"
-    "      return {\"action\": \"click_text\", \"text\": text, \"target\": text}\n"
-    
-    "# navigate: 指定した URL へナビゲートするアクション\n"
-    "  def navigate(url: str) -> Dict:\n"
-    "      return {\"action\": \"navigate\", \"target\": url}\n"
-    
-    "# type_text: 指定したターゲットにテキストを入力するアクション\n"
-    "  def type_text(target: str, value: str) -> Dict:\n"
-    "      return {\"action\": \"type\", \"target\": target, \"value\": value}\n"
-    
-    "# wait: 一定時間待機するアクション\n"
-    "  def wait(ms: int = 500, retry: int | None = None) -> Dict:\n"
-    "      act = {\"action\": \"wait\", \"ms\": ms}\n"
-    "      if retry is not None: act[\"retry\"] = retry\n"
-    "      return act\n"
-    
-    "# wait_for_selector: 指定したセレクタが出現するまで待機するアクション\n"
-    "  def wait_for_selector(target: str, ms: int = 3000) -> Dict:\n"
-    "      return {\"action\": \"wait_for_selector\", \"target\": target, \"ms\": ms}\n"
-    
-    "# go_back: ブラウザの「戻る」操作を行うアクション\n"
-    "  def go_back() -> Dict:\n"
-    "      return {\"action\": \"go_back\"}\n"
-    
-    "# go_forward: ブラウザの「進む」操作を行うアクション\n"
-    "  def go_forward() -> Dict:\n"
-    "      return {\"action\": \"go_forward\"}\n"
-    
-    "# hover: 指定したターゲットにマウスカーソルを移動させるアクション\n"
-    "  def hover(target: str) -> Dict:\n"
-    "      return {\"action\": \"hover\", \"target\": target}\n"
-    
-    "# select_option: セレクト要素から指定した値を選択するアクション\n"
-    "  def select_option(target: str, value: str) -> Dict:\n"
-    "      return {\"action\": \"select_option\", \"target\": target, \"value\": value}\n"
-    
-    "# press_key: 指定したキーを押下するアクション\n"
-    "  def press_key(key: str, target: str | None = None) -> Dict:\n"
-    "      act = {\"action\": \"press_key\", \"key\": key}\n"
-    "      if target: act[\"target\"] = target\n"
-    "      return act\n"
-    
-    "# extract_text: 指定したターゲットからテキストを抽出するアクション\n"
-    "  def extract_text(target: str) -> Dict:\n"
-    "      return {\"action\": \"extract_text\", \"target\": target}\n"
-
-    """
+        "|目的|\n"
+        "ユーザーの自然言語命令を受け取り、Playwright 互換の DSL(JSON) でブラウザ操作手順を生成します。\n"
+        "まず **現在表示されているページ(HTML ソースを渡します)** を必ず確認し、"
+        "さらに **ユーザーがページ内の具体的なテキスト情報を求めている場合は、その情報を抽出して説明に含めて返す** こと。\n"
+        "（例: 『開催概要を教えて』→ ページにある開催概要を説明文に貼り付ける）\n"
+        "\n"
+        "|出力フォーマット|\n"
+        "1 行目〜複数行 : 取得した情報や操作意図を日本語で説明。\n"
+        "    ユーザーが求めたページ内情報があれば **ここに要約または全文を含める**。\n"
+        "    80 文字制限は撤廃して良いが、最長 300 文字程度に収める。\n"
+        "その後に ```json フェンス内で DSL を出力。\n"
+        "\n"
+        "```json の中身は以下のフォーマット:\n"
+        "{\n"
+        '  "actions": [ <action_object> , ... ],\n'
+        '  "complete": true | false               # true ならタスク完了, false なら未完了で続行\n'
+        "}\n"
+        "\n"
+        "<action_object> は次のいずれか:\n"
+        '  { "action": "navigate",       "target": "https://example.com" }\n'
+        '  { "action": "click",          "target": "css=button.submit" }\n'
+        '  { "action": "click_text",     "text":   "次へ" }\n'
+        '  { "action": "type",           "target": "css=input[name=q]", "value": "検索ワード" }\n'
+        '  { "action": "wait",           "ms": 1000 }\n'
+        '  { "action": "scroll",         "target": "css=div.list", "direction": "down", "amount": 400 }\n'
+        '  { "action": "go_back" }\n'
+        '  { "action": "go_forward" }\n'
+        '  { "action": "hover",          "target": "css=div.menu" }\n'
+        '  { "action": "select_option",   "target": "css=select", "value": "option1" }\n'
+        '  { "action": "press_key",      "key": "Enter", "target": "css=input" }\n'
+        '  { "action": "wait_for_selector", "target": "css=button.ok", "ms": 3000 }\n'
+        '  { "action": "extract_text",    "target": "css=div.content" }\n\n\n'
+        "\n\n"
+        "|ルール|\n"
+        "1. 現ページで表示されている要素のみ操作してよい。ページ遷移後の要素の操作は、次のステップで生成しなくてはいけない。つまりページ遷移が必要かつ、複数のアクションがあった場合には、ページ遷移が最後のアクションである必要がある。\n"
+        "2. 与えられた情報にある要素のみ操作してよい。要素名を予想してアクションを生成することはしてはいけない。\n"
+        "3. 現ページで目的達成できる場合は `actions` を **空配列** で返し、`complete:true`。\n"
+        "4. `click` はCSSセレクタで指定します。**非表示要素(`aria-hidden='true'`など)を避け、ユニークな属性(id, name, data-testidなど)を優先してください。**\n"
+        "5. `click_text` は可視テキストで指定します。\n"
+        "6. 失敗しやすい操作には `wait` を挿入し、安定化を図ること。\n"
+        "7. 類似要素が複数ある場合は `:nth-of-type()` や `:has-text()` などで特定性を高める。\n"
+        "8. 一度に大量の操作を出さず、状況確認が必要な場合は `complete:false` とし段階的に進める。\n"
+        "9. 一度に有効な複数の操作を出す場合には、各アクションの間に１秒の待機を設ける\n"
+        "10. **ユーザーがページ内テキストを要求している場合**:\n"
+        "    - `navigate` や `click` を行わずとも情報が取れるなら `actions` は空。\n"
+        '    - 説明部にページから抽出したテキストを含める（長文は冒頭 200 文字＋"..."）。\n'
+        f"11. 最大 {MAX_STEPS} ステップ以内にタスクを完了できない場合は `complete:true` で終了してください。\n"
+        "\n"
+        "Python で利用できるアクションヘルパー関数:\n"
+        "#click: 指定したターゲットをクリックするアクション\n"
+        "  def click(target: str) -> Dict:\n"
+        '      return {"action": "click", "target": target}\n'
+        "#click_text: 指定したテキストを持つ要素をクリックするアクション\n"
+        "  def click_text(text: str) -> Dict:\n"
+        '      return {"action": "click_text", "text": text, "target": text}\n'
+        "# navigate: 指定した URL へナビゲートするアクション\n"
+        "  def navigate(url: str) -> Dict:\n"
+        '      return {"action": "navigate", "target": url}\n'
+        "# type_text: 指定したターゲットにテキストを入力するアクション\n"
+        "  def type_text(target: str, value: str) -> Dict:\n"
+        '      return {"action": "type", "target": target, "value": value}\n'
+        "# wait: 一定時間待機するアクション\n"
+        "  def wait(ms: int = 500, retry: int | None = None) -> Dict:\n"
+        '      act = {"action": "wait", "ms": ms}\n'
+        '      if retry is not None: act["retry"] = retry\n'
+        "      return act\n"
+        "# wait_for_selector: 指定したセレクタが出現するまで待機するアクション\n"
+        "  def wait_for_selector(target: str, ms: int = 3000) -> Dict:\n"
+        '      return {"action": "wait_for_selector", "target": target, "ms": ms}\n'
+        "# go_back: ブラウザの「戻る」操作を行うアクション\n"
+        "  def go_back() -> Dict:\n"
+        '      return {"action": "go_back"}\n'
+        "# go_forward: ブラウザの「進む」操作を行うアクション\n"
+        "  def go_forward() -> Dict:\n"
+        '      return {"action": "go_forward"}\n'
+        "# hover: 指定したターゲットにマウスカーソルを移動させるアクション\n"
+        "  def hover(target: str) -> Dict:\n"
+        '      return {"action": "hover", "target": target}\n'
+        "# select_option: セレクト要素から指定した値を選択するアクション\n"
+        "  def select_option(target: str, value: str) -> Dict:\n"
+        '      return {"action": "select_option", "target": target, "value": value}\n'
+        "# press_key: 指定したキーを押下するアクション\n"
+        "  def press_key(key: str, target: str | None = None) -> Dict:\n"
+        '      act = {"action": "press_key", "key": key}\n'
+        '      if target: act["target"] = target\n'
+        "      return act\n"
+        "# extract_text: 指定したターゲットからテキストを抽出するアクション\n"
+        "  def extract_text(target: str) -> Dict:\n"
+        '      return {"action": "extract_text", "target": target}\n'
+        """
     === ブラウザ操作 DSL 出力ルール（必読・厳守）================================
     目的 : Playwright 側 /execute-dsl エンドポイントで 100% 受理・実行可能な
             JSON を生成し、「locator not found」や Timeout を極小化すること。
@@ -268,17 +266,17 @@ def build_prompt(cmd: str, page: str, hist, screenshot: bool = False, elements: 
     }\n
     ========================================================================
     """
-    "\n"
-    "---- 操作候補要素一覧 (操作対象は番号で指定) ----\n"
-    f"{elem_lines}\n"
-    "--------------------------------\n"
-    "---- 現在のページ HTML(一部) ----\n"
-    f"{strip_html(page)}\n"
-    "--------------------------------\n"
-    f"## これまでの会話履歴\n{past_conv}\n"
-    "--------------------------------\n"
-    f"## ユーザー命令\n{cmd}\n"
-    f"{add_img}"
+        "\n"
+        "---- 操作候補要素一覧 (操作対象は番号で指定) ----\n"
+        f"{elem_lines}\n"
+        "--------------------------------\n"
+        "---- 現在のページ DOM ----\n"
+        f"{dom_text}\n"
+        "--------------------------------\n"
+        f"## これまでの会話履歴\n{past_conv}\n"
+        "--------------------------------\n"
+        f"## ユーザー命令\n{cmd}\n"
+        f"{add_img}"
     )
 
     return system_prompt


### PR DESCRIPTION
## Summary
- avoid sending entire HTML to the LLM
- send DOM tree text instead
- add helper methods for DOMElementNode
- handle evaluation errors in automation server
- add SPA_STABILIZE_TIMEOUT constant

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f39e17d088320ba836b7204fc295e