### PR TITLE
Fix DOM highlight feature

### DIFF
--- a/vnc/buildDomTree.js
+++ b/vnc/buildDomTree.js
@@ -125,4 +125,4 @@ function buildDomTree(opts) {
   return tree;
 }
 
-return buildDomTree(arguments[0]);
+return buildDomTree(opts);

--- a/web/static/browser_executor.js
+++ b/web/static/browser_executor.js
@@ -236,11 +236,10 @@ if (stopBtn) {
 }
 
 let highlightOn = false;
-const highlightBtn = document.getElementById("highlight-toggle");
-if (highlightBtn) {
-  highlightBtn.addEventListener("click", async () => {
-    highlightOn = !highlightOn;
-    highlightBtn.textContent = highlightOn ? "ハイライトOFF" : "ハイライト";
+const highlightSwitch = document.getElementById("highlight-switch");
+if (highlightSwitch) {
+  highlightSwitch.addEventListener("change", async () => {
+    highlightOn = highlightSwitch.checked;
     try {
       await fetch(`/dom-tree?highlight=${highlightOn ? 1 : 0}`);
     } catch (e) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -213,6 +213,45 @@ footer {
     z-index: 999;
 }
 
+/* ----- highlight switch ----- */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 24px;
+}
+.switch input {
+    display: none;
+}
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 24px;
+}
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+input:checked + .slider {
+    background-color: #4caf50;
+}
+input:checked + .slider:before {
+    transform: translateX(26px);
+}
+
 
 
 

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -34,7 +34,10 @@
       <button id="memory-button">履歴</button>
       <button id="reset-button">リセット</button>
       <button id="history-toggle">ログ</button>
-      <button id="highlight-toggle">ハイライト</button>
+      <label class="switch">
+        <input type="checkbox" id="highlight-switch">
+        <span class="slider"></span>
+      </label>
     </div>
     <!-- ★★★ ここまで ------------------------------------------ -->
 


### PR DESCRIPTION
## Summary
- highlight interactive elements correctly by passing opts to injected script
- convert highlight toggle to a switch
- implement switch style and event handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node -c vnc/buildDomTree.js`


------
https://chatgpt.com/codex/tasks/task_e_688056b40d188320a8d52259c31e2269