### PR TITLE
Improve error handling in DOM retrieval

### DIFF
--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -52,13 +52,16 @@ def get_extracted() -> list:
         return []
 
 
-def get_dom_tree() -> DOMElementNode | None:
-    """Retrieve full DOM tree structure."""
+def get_dom_tree() -> tuple[DOMElementNode | None, str | None]:
+    """Retrieve full DOM tree structure.
+
+    Returns a tuple of (DOM tree or None, error message or None).
+    """
     try:
         res = requests.get(f"{VNC_API}/dom-tree", timeout=30)
         res.raise_for_status()
         data = res.json()
-        return DOMElementNode.from_json(data)
+        return DOMElementNode.from_json(data), None
     except Exception as e:
         log.error("get_dom_tree error: %s", e)
-        return None
+        return None, str(e)

--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -20,6 +20,7 @@ def build_prompt(
     hist,
     screenshot: bool = False,
     elements: DOMElementNode | list | None = None,
+    error: str | None = None,
 ) -> str:
     """Return full system prompt for the LLM."""
     past_conv = "\n".join(f"U:{h['user']}\nA:{h['bot']['explanation']}" for h in hist)
@@ -30,6 +31,7 @@ def build_prompt(
         else ""
     )
     elem_lines = ""
+    error_line = f"## サーバーエラー\n{error}\n--------------------------------\n" if error else ""
     dom_text = strip_html(page)
     if elements:
         nodes: list[DOMElementNode] = []
@@ -287,6 +289,7 @@ def build_prompt(
         "--------------------------------\n"
         f"## ユーザー命令\n{cmd}\n"
         f"{add_img}"
+        f"{error_line}"
     )
     
     #print(dom_text)

--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -217,6 +217,7 @@ async def _build_dom_tree():
     with open(script_path, encoding="utf-8") as f:
         script = f.read()
     try:
+        await _stabilize_page()
         return await PAGE.evaluate(f"(() => {{ {script}\n }})()")
     except Exception as e:
         log.error("dom_tree evaluate failed: %s", e)

--- a/web/app.py
+++ b/web/app.py
@@ -81,8 +81,8 @@ def execute():
     shot = data.get("screenshot")
     model = data.get("model", "gemini")
     hist = load_hist()
-    elements = vnc_dom_tree()
-    prompt = build_prompt(cmd, page, hist, bool(shot), elements)
+    elements, dom_err = vnc_dom_tree()
+    prompt = build_prompt(cmd, page, hist, bool(shot), elements, dom_err)
     res = call_llm(prompt, model, shot)
 
     hist.append({"user": cmd, "bot": res})


### PR DESCRIPTION
## Summary
- return DOM tree errors to caller so prompts can include them
- show server error messages inside prompt
- stabilize page before building DOM tree
- propagate DOM tree errors through web app

## Testing
- `pytest -q`
- `python -m py_compile agent/browser/vnc.py agent/controller/prompt.py web/app.py vnc/automation_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6880636ef7e88320b7cdbf9e3e3cbf80