### PR TITLE
Fix DOM tree retrieval fallback

### DIFF
--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -61,6 +61,8 @@ def get_dom_tree() -> tuple[DOMElementNode | None, str | None]:
         res = requests.get(f"{VNC_API}/dom-tree", timeout=30)
         res.raise_for_status()
         data = res.json()
+        if not data:
+            raise ValueError("empty dom tree")
         return DOMElementNode.from_json(data), None
     except Exception as e:
         log.error("get_dom_tree error: %s", e)

--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -218,9 +218,13 @@ async def _build_dom_tree():
         script = f.read()
     try:
         await _stabilize_page()
-        return await PAGE.evaluate(f"(() => {{ {script}\n }})()")
+        # Evaluate the script directly.  The JS file already returns the
+        # generated tree, so we simply execute it in the page context.
+        return await PAGE.evaluate(script)
     except Exception as e:
-        log.error("dom_tree evaluate failed: %s", e)
+        # Log stack trace for easier debugging and return None so that the
+        # caller can fall back to other methods.
+        log.exception("dom_tree evaluate failed: %s", e)
         return None
 
 


### PR DESCRIPTION
## Summary
- evaluate DOM building script directly for more reliable result
- fallback to `/elements` when DOM tree retrieval fails
- convert fallback element list to DOMElementNode

## Testing
- `python -m py_compile web/app.py agent/browser/vnc.py vnc/automation_server.py agent/controller/prompt.py`

------
https://chatgpt.com/codex/tasks/task_e_68817eec8328832084c68975df1b8a7d