### PR TITLE
Improve interactive element detection

### DIFF
--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -42,6 +42,7 @@ def build_prompt(
             for n in elements:
                 if isinstance(n, DOMElementNode):
                     _collect_interactive(n, nodes)
+        nodes.sort(key=lambda x: x.highlightIndex or 0)
         elem_lines = "\n".join(
             f"[{n.highlightIndex}] <{n.tagName}> {n.text or ''} id={n.attributes.get('id')} class={n.attributes.get('class')}"
             for n in nodes

--- a/vnc/buildDomTree.js
+++ b/vnc/buildDomTree.js
@@ -21,13 +21,30 @@ function buildDomTree() {
            style.visibility !== 'hidden' && style.display !== 'none';
   }
 
+  function hasAnyHandler(el) {
+    for (const key in el) {
+      if (key.startsWith('on') && typeof el[key] === 'function') {
+        return true;
+      }
+    }
+    for (const a of el.attributes) {
+      if (a.name.startsWith('on')) return true;
+    }
+    if (typeof getEventListeners === 'function') {
+      const listeners = getEventListeners(el);
+      for (const k in listeners) {
+        if (listeners[k] && listeners[k].length > 0) return true;
+      }
+    }
+    return false;
+  }
+
   function isInteractive(el) {
     const tag = el.tagName.toLowerCase();
     const role = el.getAttribute('role') || '';
     const tags = ['a','button','input','select','textarea','option'];
     const roles = ['button','link','checkbox','radio','textbox','tab','option','menuitem'];
-    return tags.includes(tag) || roles.includes(role) ||
-           typeof el.onclick === 'function' || typeof el.onchange === 'function';
+    return tags.includes(tag) || roles.includes(role) || hasAnyHandler(el);
   }
 
   function isTopElement(el) {


### PR DESCRIPTION
## Summary
- detect any event handlers when building DOM tree
- sort interactive nodes so prompt lists all operable elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bd2fb24883209d60ed534030bd66