### PR TITLE
Fix DOM tree script evaluation

### DIFF
--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -230,11 +230,11 @@ async def _build_dom_tree():
     script_path = os.path.join(os.path.dirname(__file__), "buildDomTree.js")
     with open(script_path, encoding="utf-8") as f:
         script = f.read()
+    js = f"(function(){{{script}}})()"
     try:
         await _stabilize_page()
-        # Evaluate the script directly.  The JS file already returns the
-        # generated tree, so we simply execute it in the page context.
-        return await PAGE.evaluate(script)
+        # Evaluate the wrapped script which returns the generated tree.
+        return await PAGE.evaluate(js)
     except Exception as e:
         # Log stack trace for easier debugging and return None so that the
         # caller can fall back to other methods.


### PR DESCRIPTION
## Summary
- wrap DOM tree script in an IIFE so it evaluates correctly

## Testing
- `curl -v http://127.0.0.1:7000/dom-tree` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6881c9731f088320a21fef27e90be84c