### PR TITLE
Improve DOM tree retrieval

### DIFF
--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -66,4 +66,11 @@ def get_dom_tree() -> tuple[DOMElementNode | None, str | None]:
         return DOMElementNode.from_json(data), None
     except Exception as e:
         log.error("get_dom_tree error: %s", e)
+        # Fallback to parsing raw HTML so that the caller still gets a DOM tree
+        try:
+            html = get_html()
+            if html:
+                return DOMElementNode.from_html(html), str(e)
+        except Exception as fe:
+            log.error("fallback dom_tree parse error: %s", fe)
         return None, str(e)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -2,4 +2,5 @@ Flask
 flask-cors
 requests
 groq
-google-generativeai 
+google-generativeai
+beautifulsoup4


### PR DESCRIPTION
## Summary
- parse HTML to DOM when `/dom-tree` endpoint fails
- support new `DOMElementNode.from_html()` helper for fallback parsing
- add `beautifulsoup4` dependency

## Testing
- `python -m py_compile agent/browser/dom.py agent/browser/vnc.py`

------
https://chatgpt.com/codex/tasks/task_e_6881da4c4058832093b7784983f63ece