### PR TITLE
Remove style/script from DOM tree

### DIFF
--- a/agent/browser/dom.py
+++ b/agent/browser/dom.py
@@ -41,6 +41,10 @@ class DOMElementNode:
         from bs4 import BeautifulSoup, NavigableString, Tag
 
         soup = BeautifulSoup(html, "html.parser")
+        # Remove <script> and <style> tags entirely to keep the DOM concise
+        for t in soup.find_all(["script", "style"]):
+            t.decompose()
+
         counter = 1
         interactive_tags = {
             "a",
@@ -72,6 +76,8 @@ class DOMElementNode:
                     return None
                 return cls(tagName="#text", text=text)
             if not isinstance(node, Tag):
+                return None
+            if node.name in {"script", "style"}:
                 return None
 
             children = [c for c in (traverse(ch) for ch in node.children) if c]


### PR DESCRIPTION
## Summary
- strip `<script>` and `<style>` tags when constructing the DOM tree from HTML
- guard against these tags inside tree traversal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e0a533788320b3bd99c5cc3f3ec4