### PR TITLE
Add fallback selectors with retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ GROQ_API_KEY=<Your Groq API Key>
 
 Playwright の API を直接呼び出すのではなく、LLM で生成した JSON DSL を `automation_server.py` に転送することでブラウザ操作を行う設計になっています。
 
+### セレクタのフォールバック
+
+DSL の `target` には `css=#login || text=ログイン` のように `||` 区切りで複数の
+セレクタを指定できます。左から順に `data-testid` や ARIA role、テキスト、CSS など
+を自動判別して探索し、見つからない場合は次の候補へフォールバックするため、動的 UI
+でも壊れにくい操作が可能です。
+

--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -274,6 +274,8 @@ async def _apply(act: Dict):
     global PAGE
     a = act["action"]
     tgt = act.get("target", "")
+    if isinstance(tgt, list):
+        tgt = " || ".join(str(s).strip() for s in tgt if s)
     val = act.get("value", "")
     ms = int(act.get("ms", 0))
     amt = int(act.get("amount", 400))

--- a/vnc/locator_utils.py
+++ b/vnc/locator_utils.py
@@ -11,6 +11,9 @@ SmartLocator — どのサイトにも耐える多段フォールバックロケ
  6) 裸の CSS セレクタ
 
 各候補を 3000 ms 以内に発見できなければ次へ。
+
+target に "css=btn || text=Next" のように "||" 区切りで複数の
+候補を与えると、左から順に試行する。
 """
 from __future__ import annotations
 import re, os
@@ -36,6 +39,14 @@ class SmartLocator:
 
     async def locate(self) -> Optional[Locator]:
         t = self.raw
+
+        # Multiple fallbacks separated by "||"
+        if "||" in t:
+            for cand in [c.strip() for c in t.split("||") if c.strip()]:
+                loc = await SmartLocator(self.page, cand).locate()
+                if loc:
+                    return loc
+            return None
 
         # 明示プレフィクス
         if t.startswith("css="):


### PR DESCRIPTION
## Summary
- extend SmartLocator to accept `||` separated selectors for fallback
- support list targets in automation server
- document selector fallback in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688971bde1748320a9a872e9f8d08823