### PR TITLE
Improve eval_js action

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,22 @@ DSL の `target` には `css=#login || text=ログイン` のように `||` 区�
 を自動判別して探索し、見つからない場合は次の候補へフォールバックするため、動的 UI
 でも壊れにくい操作が可能です。
 
+### eval_js アクションの使い方
+
+`eval_js` はページ内で任意の JavaScript を実行したい場合に利用します。例えば、
+組み込みアクションだけでは取得できない動的な値の確認や、SPA 特有の関数呼び出しを
+行いたいときに便利です。実行結果は自動的に記録され、`/eval_results` エンドポイント
+もしくは `agent.browser.vnc.get_eval_results()` から取得できます。値を取得して条件
+分岐したい場合は次のようにします。
+
+```python
+from agent.browser import vnc
+
+# ボタン数を数えて2個以上ならクリック
+count = vnc.eval_js("document.querySelectorAll('button').length")
+if count and int(count) > 1:
+    vnc.execute_dsl({"actions": [{"action": "click", "target": "css=button"}]})
+```
+
+上記のように、ページ状態を細かく把握してから次の操作を決定することが可能です。
+

--- a/agent/actions/basic.py
+++ b/agent/actions/basic.py
@@ -58,5 +58,10 @@ def extract_text(target: str) -> Dict:
 
 
 def eval_js(script: str) -> Dict:
-    """Execute arbitrary JavaScript in the page context."""
+    """Execute JavaScript in the page and store the result.
+
+    Use this when built-in actions cannot express a complex operation or when
+    page state must be inspected via DOM APIs.  The returned value is recorded
+    by the automation server and can be fetched with :func:`get_eval_results`.
+    """
     return {"action": "eval_js", "script": script}

--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -52,10 +52,23 @@ def get_extracted() -> list:
         return []
 
 
-def eval_js(script: str) -> None:
-    """Send a JavaScript snippet to be executed in the browser."""
+def get_eval_results() -> list:
+    """Retrieve results of the most recent eval_js calls."""
+    try:
+        res = requests.get(f"{VNC_API}/eval_results", timeout=30)
+        res.raise_for_status()
+        return res.json()
+    except Exception as e:
+        log.error("get_eval_results error: %s", e)
+        return []
+
+
+def eval_js(script: str):
+    """Execute JavaScript and return its result if any."""
     payload = {"actions": [{"action": "eval_js", "script": script}]}
     execute_dsl(payload)
+    res = get_eval_results()
+    return res[-1] if res else None
 
 
 def get_dom_tree() -> tuple[DOMElementNode | None, str | None]:

--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -31,7 +31,11 @@ def build_prompt(
         else ""
     )
     elem_lines = ""
-    error_line = f"## サーバーエラー\n{error}\n--------------------------------\n" if error else ""
+    error_line = (
+        f"## サーバーエラー\n{error}\n--------------------------------\n"
+        if error
+        else ""
+    )
     dom_text = strip_html(page)
     if elements:
         nodes: list[DOMElementNode] = []
@@ -205,9 +209,10 @@ def build_prompt(
         "# extract_text: 指定したターゲットからテキストを抽出するアクション\n"
         "  def extract_text(target: str) -> Dict:\n"
         '      return {"action": "extract_text", "target": target}\n'
-        "# eval_js: 任意の JavaScript を実行するアクション\n"
+        "# eval_js: 任意の JavaScript を実行して結果を保存するアクション\n"
         "  def eval_js(script: str) -> Dict:\n"
         '      return {"action": "eval_js", "script": script}\n'
+        "#   DOM 状態の確認や動的値の取得に使い、戻り値は後から取得可能\n"
         """
     === ブラウザ操作 DSL 出力ルール（必読・厳守）================================
     目的 : Playwright 側 /execute-dsl エンドポイントで 100% 受理・実行可能な
@@ -290,10 +295,9 @@ def build_prompt(
         "\n"
         "---- 操作候補要素一覧 (操作対象は番号で指定) ----\n"
         f"{elem_lines}\n"
-        "--------------------------------\n"   
+        "--------------------------------\n"
         "---- 現在のページ DOM ----\n"
         f"{dom_text}\n"
-
         "--------------------------------\n"
         "## これまでの会話履歴\n"
         f"{past_conv}\n"
@@ -306,6 +310,6 @@ def build_prompt(
         "## 現在のエラー状況\n"
         f"{error_line}"
     )
-    #print(dom_text)
+    # print(dom_text)
 
     return system_prompt


### PR DESCRIPTION
## Summary
- document how to use `eval_js` and how its return value can be fetched
- store JavaScript evaluation results on the automation server
- expose `/eval_results` endpoint and add browser helper functions
- update system prompt to note the new behaviour
- expand `eval_js` helper docstring

## Testing
- `black vnc/automation_server.py agent/browser/vnc.py agent/actions/basic.py agent/controller/prompt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b1341154832080903107d089a22e