### PR TITLE
propagate locator warnings

### DIFF
--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -20,11 +20,11 @@ def get_html() -> str:
 def execute_dsl(payload, timeout=120):
     """Forward DSL JSON to the automation server."""
     if not payload.get("actions"):
-        return ""
+        return {"html": "", "warnings": []}
     try:
         r = requests.post(f"{VNC_API}/execute-dsl", json=payload, timeout=None)
         r.raise_for_status()
-        return r.text
+        return r.json()
     except requests.Timeout:
         log.error("execute_dsl timeout")
         raise

--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -31,11 +31,16 @@ def build_prompt(
         else ""
     )
     elem_lines = ""
-    error_line = (
-        f"## サーバーエラー\n{error}\n--------------------------------\n"
-        if error
-        else ""
-    )
+    error_line = ""
+    if error:
+        if isinstance(error, list):
+            lines = [e for e in error if "locator not found" in e]
+        else:
+            lines = [e for e in str(error).splitlines() if "locator not found" in e]
+        if lines:
+            error_line = (
+                "## 現在のエラー状況\n" + "\n".join(lines) + "\n--------------------------------\n"
+            )
     dom_text = strip_html(page)
     if elements:
         nodes: list[DOMElementNode] = []

--- a/web/app.py
+++ b/web/app.py
@@ -121,10 +121,10 @@ def execute():
 def forward_dsl():
     payload = request.get_json(force=True)
     if not payload.get("actions"):
-        return Response("", 200, mimetype="text/plain")
+        return jsonify({"html": "", "warnings": []})
     try:
-        res_text = execute_dsl(payload, timeout=120)
-        return Response(res_text, 200, mimetype="text/plain")
+        res_obj = execute_dsl(payload, timeout=120)
+        return jsonify(res_obj)
     except requests.Timeout:
         log.error("forward_dsl timeout")
         return jsonify(error="timeout"), 504

--- a/web/static/browser_executor.js
+++ b/web/static/browser_executor.js
@@ -82,8 +82,9 @@ async function sendDSL(acts) {
       return { html: "", error: msg || `status ${r.status}` };
     } else {
       appendHistory(acts);
-      const text = await r.text();
-      return { html: text, error: null };
+      const j = await r.json();
+      const err = j.warnings && j.warnings.length ? j.warnings.join("\n") : null;
+      return { html: j.html || "", error: err };
     }
   } catch (e) {
     console.error("execute-dsl fetch error:", e);


### PR DESCRIPTION
## Summary
- capture locator-not-found warnings in automation server and surface them to the frontend
- include current warning lines in prompt generation under `## 現在のエラー状況`
- adjust DSL execution pipeline to pass warning info via JSON responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d809a0ff8832091f95240d2927b2a