### PR TITLE
Include error messages in prompt

### DIFF
--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -34,13 +34,15 @@ def build_prompt(
     error_line = ""
     if error:
         if isinstance(error, list):
-            lines = [e for e in error if "locator not found" in e]
+            err_lines: list[str] = []
+            for e in error:
+                err_lines.extend(str(e).splitlines())
         else:
-            lines = [e for e in str(error).splitlines() if "locator not found" in e]
+            err_lines = str(error).splitlines()
+        keywords = ("error", "timeout", "not found", "traceback", "visible")
+        lines = [l for l in err_lines if any(k in l.lower() for k in keywords)]
         if lines:
-            error_line = (
-                 "\n".join(lines) + "\n--------------------------------\n"
-            )
+            error_line = "\n".join(lines[-10:]) + "\n--------------------------------\n"
     dom_text = strip_html(page)
     if elements:
         nodes: list[DOMElementNode] = []


### PR DESCRIPTION
## Summary
- capture broader error details for LLM prompts

## Testing
- `pytest`
- `python -m py_compile agent/controller/prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_688d8cad8a148320a269dc563dda0884