### PR TITLE
Allow click_text to use multiple fallback selectors

### DIFF
--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -327,7 +327,10 @@ async def _apply(act: Dict):
     loc: Optional = None
     for _ in range(LOCATOR_RETRIES):
         if a == "click_text":
-            loc = await SmartLocator(PAGE, f"text={tgt}").locate()
+            if "||" in tgt or tgt.strip().startswith(("css=", "text=", "role=", "xpath=")):
+                loc = await SmartLocator(PAGE, tgt).locate()
+            else:
+                loc = await SmartLocator(PAGE, f"text={tgt}").locate()
         else:
             loc = await SmartLocator(PAGE, tgt).locate()
         if loc is not None:


### PR DESCRIPTION
## Summary
- support `||`-separated fallback selectors in `click_text`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f11af53848320ad06de91ae600f48