### PR TITLE
Remove input status indicator from chat interface

### DIFF
--- a/web/static/chat_integration.js
+++ b/web/static/chat_integration.js
@@ -4,33 +4,18 @@ document.addEventListener("DOMContentLoaded", () => {
   const userInput   = document.getElementById("user-input");
   const chatArea    = document.getElementById("chat-area");
   const resetBtn    = document.getElementById("reset-button");
-  const inputStatus = document.getElementById("input-status");
 
-  // Update input status based on execution state
-  function updateInputStatus() {
+  // Update input placeholder based on execution state
+  function updateInputPlaceholder() {
     if (typeof window.isTaskExecuting === "function" && window.isTaskExecuting()) {
-      if (typeof window.getQueuedPromptCount === "function") {
-        const queueCount = window.getQueuedPromptCount();
-        if (queueCount > 0) {
-          inputStatus.textContent = `🔄 実行中 - 追加指示 ${queueCount}件 待機中`;
-          inputStatus.style.color = "#ff9800";
-        } else {
-          inputStatus.textContent = "🔄 実行中 - 追加指示を入力できます";
-          inputStatus.style.color = "#007bff";
-        }
-      } else {
-        inputStatus.textContent = "🔄 実行中";
-        inputStatus.style.color = "#007bff";
-      }
       userInput.placeholder = "追加の指示やアドバイスを入力...";
     } else {
-      inputStatus.textContent = "";
       userInput.placeholder = "ここに入力...";
     }
   }
 
-  // Monitor execution state and update input status
-  setInterval(updateInputStatus, 500);
+  // Monitor execution state and update input placeholder
+  setInterval(updateInputPlaceholder, 500);
 
   if (resetBtn) {
     resetBtn.addEventListener("click", async () => {

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -23,7 +23,6 @@
       <div id="input-area" style="background:#f9f9f9;padding:15px;display:flex;gap:10px;align-items:center;">
         <div style="flex:1;">
           <textarea id="user-input" rows="3" placeholder="ここに入力..." style="width:100%;border:1px solid #ddd;border-radius:8px;padding:10px;font-size:14px;resize:vertical;min-height:60px;"></textarea>
-          <div id="input-status" style="font-size:12px;color:#666;margin-top:4px;min-height:16px;"></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:8px;">
           <button style="background:linear-gradient(135deg, #6a11cb, #2575fc);color:white;border:none;border-radius:8px;padding:10px 20px;font-weight:bold;cursor:pointer;">送信</button>


### PR DESCRIPTION
## Summary
- remove "input-status" bar under chat textarea
- adjust script to update only placeholder text without status bar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4e84d92b08320af124bd71f341452