### PR TITLE
Improve stop button responsiveness with abortable fetches

### DIFF
--- a/web/static/common_executor.js
+++ b/web/static/common_executor.js
@@ -1,8 +1,10 @@
 // common_executor.js
 function sendCommand(command, pageSource, screenshot, model, errorInfo = null) {
+  const signal = window.stopController ? window.stopController.signal : undefined;
   return fetch("/execute", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ command, pageSource, screenshot, model, error: errorInfo })
+    body: JSON.stringify({ command, pageSource, screenshot, model, error: errorInfo }),
+    signal,
   }).then(r => r.json());
 }


### PR DESCRIPTION
## Summary
- allow stop button to abort ongoing actions immediately using an AbortController
- wire stop requests through poll loop and fetches for quicker cancellation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4e94514b8832097e0605d199d9c21