### PR TITLE
追加指示のチャット表示を1件に統一

### DIFF
--- a/web/static/browser_executor.js
+++ b/web/static/browser_executor.js
@@ -839,8 +839,7 @@ async function executeTask(cmd, model = "gemini", placeholder = null) {
     // Check for queued prompts and process them
     if (promptQueue.length > 0) {
       const queuedPrompt = promptQueue.shift();
-      showSystemMessage(`📝 追加指示を処理中: "${queuedPrompt}"`);
-      
+
       // Process the queued prompt by updating the current command
       cmd = queuedPrompt;
       
@@ -982,7 +981,6 @@ window.executeTask = executeTask;
 window.addPromptToQueue = function(prompt) {
   if (isExecutingTask) {
     promptQueue.push(prompt);
-    showSystemMessage(`📝 実行中のため追加指示をキューに追加しました: "${prompt}"`);
     return true;
   }
   return false;

--- a/web/static/chat_integration.js
+++ b/web/static/chat_integration.js
@@ -130,7 +130,7 @@ document.addEventListener("DOMContentLoaded", () => {
         /* ユーザーメッセージを追加 */
         const u = document.createElement("p");
         u.classList.add("user-message");
-        u.innerHTML = `<strong>📝 追加指示:</strong> ${text}`;
+        u.innerHTML = `<strong>📝 追加指示をキューに追加:</strong> ${text}`;
         u.style.cssText = "background: #fff3e0; border-left: 3px solid #ff9800;";
         chatArea.appendChild(u);
         chatArea.scrollTop = chatArea.scrollHeight;


### PR DESCRIPTION
## Summary
- remove system messages when queuing or processing additional prompts
- indicate queueing directly in the user message

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e9dc7e3083208812a3f11ec3f783