### PR TITLE
Avoid unwanted navigation to Yahoo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - .:/app
     environment:
-      - START_URL=https://www.yahoo.co.jp
+      - START_URL=about:blank
 
   web:
     build: ./web
@@ -24,7 +24,7 @@ services:
     command: python -u app.py
     environment:
       - PYTHONPATH=/app
-      - START_URL=https://www.yahoo.co.jp
+      - START_URL=about:blank
     env_file:
       - .env
     ports:

--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -59,7 +59,8 @@ WAIT_FOR_SELECTOR_TIMEOUT = int(os.getenv("WAIT_FOR_SELECTOR_TIMEOUT", "5000")) 
 MAX_RETRIES = int(os.getenv("MAX_RETRIES", "3"))
 LOCATOR_RETRIES = int(os.getenv("LOCATOR_RETRIES", "3"))
 CDP_URL = "http://localhost:9222"
-DEFAULT_URL = os.getenv("START_URL", "https://yahoo.co.jp")
+# Use about:blank as the default start page to avoid unexpected navigation
+DEFAULT_URL = os.getenv("START_URL", "about:blank")
 SPA_STABILIZE_TIMEOUT = int(
     os.getenv("SPA_STABILIZE_TIMEOUT", "2000")
 )  # ms  SPA描画安定待ち

--- a/vnc/scripts/start-chromium.sh
+++ b/vnc/scripts/start-chromium.sh
@@ -8,8 +8,8 @@ for i in {1..30}; do
   echo "[chromium] waiting for X..." ; sleep 1
 done
 
-# 既定の起動 URL
-URL="${START_URL:-https://www.google.com}"
+# 既定の起動 URL を about:blank にして予期せぬ外部ページへの遷移を防ぐ
+URL="${START_URL:-about:blank}"
 
 if ! pgrep -f "--remote-debugging-port=9222" >/dev/null; then
   echo "[chromium] launching chromium..."

--- a/web/app.py
+++ b/web/app.py
@@ -82,7 +82,8 @@ def handle_exception(error):
 
 # --------------- VNC / Playwright API ----------------------------
 VNC_API = "http://vnc:7000"  # Playwright 側の API
-START_URL = os.getenv("START_URL", "https://www.yahoo.co.jp")
+# Default to a blank page to prevent unintended navigation to external sites
+START_URL = os.getenv("START_URL", "about:blank")
 MAX_STEPS = int(os.getenv("MAX_STEPS", "30"))
 
 # --------------- Conversation History ----------------------------

--- a/web/static/browser_executor.js
+++ b/web/static/browser_executor.js
@@ -14,7 +14,8 @@ const sleep = ms => new Promise(resolve => {
 const chatArea   = document.getElementById("chat-area");
 let stopRequested   = false;
 window.stopRequested = false;  // Make it globally accessible
-const START_URL = window.START_URL || "https://www.yahoo.co.jp";
+// Default to a blank page to avoid unexpected navigation
+const START_URL = window.START_URL || "about:blank";
 
 // screenshot helper
 async function captureScreenshot() {


### PR DESCRIPTION
## Summary
- Default all components to `about:blank` instead of Yahoo to prevent unexpected navigation
- Start Chromium with `about:blank` by default

## Testing
- `playwright install chromium` *(fails: ERR_SOCKET_CLOSED)*
- `pytest -q` *(fails: BrowserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d9b191483208e379e9fd2335d50