### PR TITLE
Log current URL in conversation history

### DIFF
--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -28,6 +28,18 @@ def get_html() -> str:
         return ""
 
 
+def get_url() -> str:
+    """Fetch current page URL from the VNC automation server."""
+    try:
+        res = requests.get(f"{VNC_API}/url", timeout=5)
+        res.raise_for_status()
+        data = res.json()
+        return data.get("url", "")
+    except Exception as e:
+        log.error("get_url error: %s", e)
+        return ""
+
+
 def _truncate_warning(warning_msg, max_length=None):
     """Return warning message without truncation (character limits removed)."""
     # Character limits removed for conversation history as requested

--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -1582,6 +1582,19 @@ def source():
         return Response("", mimetype="text/plain")
 
 
+@app.get("/url")
+def current_url():
+    try:
+        # Only initialize browser if it's not already healthy
+        if not PAGE or not _run(_check_browser_health()):
+            _run(_init_browser())
+        url = _run(PAGE.url()) if PAGE else ""
+        return jsonify({"url": url})
+    except Exception as e:
+        log.error("url error: %s", e)
+        return jsonify({"url": ""})
+
+
 @app.get("/screenshot")
 def screenshot():
     try:

--- a/web/app.py
+++ b/web/app.py
@@ -18,6 +18,7 @@ from agent.browser.vnc import (
     execute_dsl,
     get_elements as vnc_elements,
     get_dom_tree as vnc_dom_tree,
+    get_url as vnc_url,
 )
 from agent.browser.dom import DOMElementNode
 from agent.controller.prompt import build_prompt
@@ -201,6 +202,7 @@ def execute():
     model = data.get("model", "gemini")
     prev_error = data.get("error")
     hist = load_hist()
+    current_url = data.get("url") or vnc_url()
     elements, dom_err = vnc_dom_tree()
     if elements is None:
         try:
@@ -232,8 +234,8 @@ def execute():
     # Call LLM first
     res = call_llm(prompt, model, shot)
 
-    # Save conversation history immediately
-    hist.append({"user": cmd, "bot": res})
+    # Save conversation history immediately with current URL
+    hist.append({"user": cmd, "bot": res, "url": current_url})
     save_hist(hist)
     
     # Extract and normalize actions from LLM response


### PR DESCRIPTION
## Summary
- add VNC endpoint to return current page URL and client helper to fetch it
- store the current URL with each conversation history entry

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1117/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68c52a66aec0832099417849c212113d