### PR TITLE
Set Yahoo Japan as initial default page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     volumes:
       - .:/app
     environment:
-      - START_URL=about:blank
+      # Show Yahoo Japan only on the first browser launch
+      - START_URL=https://www.yahoo.co.jp/
 
   web:
     build: ./web
@@ -24,7 +25,8 @@ services:
     command: python -u app.py
     environment:
       - PYTHONPATH=/app
-      - START_URL=about:blank
+      # Ensure front-end matches initial Yahoo start page
+      - START_URL=https://www.yahoo.co.jp/
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## Summary
- Show Yahoo Japan when the browser launches for the first time only
- Keep the front-end configuration consistent with the browser's start page

## Testing
- `pytest -q` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c52c53d4e4832085755e25bab25951