### PR TITLE
Ensure page URLs are saved with conversation history

### DIFF
--- a/agent/utils/history.py
+++ b/agent/utils/history.py
@@ -59,3 +59,34 @@ def save_hist(h):
                 os.remove(temp_file)
         except Exception:
             pass
+
+
+def append_history_entry(user, bot, url=None):
+    """Append a single conversation interaction ensuring URL is stored.
+
+    Parameters
+    ----------
+    user : str
+        The user command or message.
+    bot : Any
+        The bot response to persist.
+    url : str, optional
+        The page URL at the time of interaction. If ``None``, an attempt is
+        made to retrieve the current URL from the VNC browser module.
+    """
+
+    try:
+        history = load_hist()
+
+        if url is None:
+            try:
+                from agent.browser.vnc import get_url
+                url = get_url()
+            except Exception:
+                url = None
+
+        history.append({"user": user, "bot": bot, "url": url})
+        save_hist(history)
+    except Exception as e:
+        log.error("append_history_entry error: %s", e)
+

--- a/web/app.py
+++ b/web/app.py
@@ -23,7 +23,7 @@ from agent.browser.vnc import (
 from agent.browser.dom import DOMElementNode
 from agent.controller.prompt import build_prompt
 from agent.controller.async_executor import get_async_executor
-from agent.utils.history import load_hist, save_hist
+from agent.utils.history import load_hist, save_hist, append_history_entry
 from agent.utils.html import strip_html
 
 # --------------- Flask & Logger ----------------------------------
@@ -263,8 +263,7 @@ def execute():
     res = call_llm(prompt, model, shot)
 
     # Save conversation history immediately with current URL
-    hist.append({"user": cmd, "bot": res, "url": current_url})
-    save_hist(hist)
+    append_history_entry(cmd, res, current_url)
     
     # Extract and normalize actions from LLM response
     actions = normalize_actions(res)


### PR DESCRIPTION
## Summary
- Add `append_history_entry` helper to log interactions with associated page URLs
- Use new helper in `execute` endpoint to persist current page URL

## Testing
- `python -m pytest -q` *(fails: Page.wait_for_selector timeout due to missing React test element)*

------
https://chatgpt.com/codex/tasks/task_e_68c53b4e595083208aa8d519d216d2a7