### PR TITLE
Preserve current URL when recreating browser

### DIFF
--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -416,19 +416,19 @@ async def _recreate_browser():
     
     # Save current URL before closing the browser to preserve task context
     current_url = None
-    try:
-        if PAGE:
-            try:
-                current_url = await PAGE.url()
-                # Only preserve non-default URLs to avoid navigating back to Yahoo during tasks
-                if current_url and current_url != DEFAULT_URL and not current_url.startswith("about:"):
-                    log.info("Preserving current URL during browser recreation: %s", current_url)
-                else:
-                    current_url = None
-            except Exception:
+    if PAGE:
+        try:
+            current_url = await PAGE.url()
+            # Avoid restoring internal about: pages
+            if current_url and not current_url.startswith("about:"):
+                log.info(
+                    "Preserving current URL during browser recreation: %s",
+                    current_url,
+                )
+            else:
                 current_url = None
-    except Exception:
-        current_url = None
+        except Exception:
+            current_url = None
     
     try:
         if PAGE:


### PR DESCRIPTION
## Summary
- capture current page URL before restarting the browser
- navigate back to preserved URL after browser recreation

## Testing
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist or is not executable)*

------
https://chatgpt.com/codex/tasks/task_e_68c78e25273c8320b58eeea49f23307f