### PR TITLE
Implement catalog-based index targeting and new DSL actions

### DIFF
--- a/agent/actions/basic.py
+++ b/agent/actions/basic.py
@@ -94,11 +94,21 @@ def click_blank_area() -> Dict:
 
 def close_popup() -> Dict:
     """Close popups by clicking on blank areas.
-    
+
     Uses popup detection and blank area clicking to close modals/overlays
     without needing to target specific close buttons or elements.
-    
+
     Returns:
         Dictionary representing a popup close action
     """
     return {"action": "close_popup"}
+
+
+def refresh_catalog() -> Dict:
+    """Refresh the element catalog prior to issuing index-based commands."""
+    return {"action": "refresh_catalog"}
+
+
+def scroll_to_text(text: str) -> Dict:
+    """Scroll to the area containing the specified text snippet."""
+    return {"action": "scroll_to_text", "target": text}

--- a/agent/browser/vnc.py
+++ b/agent/browser/vnc.py
@@ -270,6 +270,18 @@ def get_elements() -> list:
         raise
 
 
+def get_element_catalog(refresh: bool = False) -> dict:
+    """Retrieve the element catalog from the automation server."""
+    params = {"refresh": "true"} if refresh else None
+    try:
+        res = requests.get(f"{VNC_API}/catalog", params=params, timeout=(5, 30))
+        res.raise_for_status()
+        return res.json()
+    except Exception as e:
+        log.error("get_element_catalog error: %s", e)
+        raise
+
+
 def get_extracted() -> list:
     """Retrieve texts captured via extract_text action."""
     try:

--- a/agent/controller/async_executor.py
+++ b/agent/controller/async_executor.py
@@ -88,7 +88,13 @@ class AsyncExecutor:
         
         return task_id
     
-    def submit_playwright_execution(self, task_id: str, execute_func: Callable, actions: list) -> bool:
+    def submit_playwright_execution(
+        self,
+        task_id: str,
+        execute_func: Callable,
+        actions: list,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """Submit Playwright execution for async processing (optimized for immediate execution)."""
         task = self.tasks.get(task_id)
         if not task:
@@ -111,7 +117,10 @@ class AsyncExecutor:
                 log.debug("Starting execution for task %s", task_id)
                 
                 # Execute the Playwright operations immediately
-                result = execute_func({"actions": actions})
+                payload_data: Dict[str, Any] = {"actions": actions}
+                if payload:
+                    payload_data.update(payload)
+                result = execute_func(payload_data)
                 
                 # Ensure warnings are properly formatted and truncated
                 if result and isinstance(result, dict):

--- a/agent/element_catalog.py
+++ b/agent/element_catalog.py
@@ -1,0 +1,126 @@
+"""Utilities for fetching and formatting the browser element catalog."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from agent.browser import vnc
+
+log = logging.getLogger(__name__)
+INDEX_MODE_ENABLED = os.getenv("INDEX_MODE", "true").lower() == "true"
+
+_cached_catalog: Optional[Dict[str, Any]] = None
+
+
+def _normalize_catalog(raw: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raw = {}
+    metadata = raw.get("metadata") or {}
+    catalog_version = raw.get("catalog_version") or metadata.get("catalog_version")
+    return {
+        "abbreviated": raw.get("abbreviated", []),
+        "full": raw.get("full", []),
+        "metadata": metadata,
+        "catalog_version": catalog_version,
+        "index_mode_enabled": raw.get("index_mode_enabled", INDEX_MODE_ENABLED),
+        "error": raw.get("error"),
+    }
+
+
+def is_enabled() -> bool:
+    """Return True when index-based catalog mode is enabled."""
+    return INDEX_MODE_ENABLED
+
+
+def reset_cache() -> None:
+    global _cached_catalog
+    _cached_catalog = None
+
+
+def get_catalog(refresh: bool = False) -> Dict[str, Any]:
+    """Return the element catalog, optionally forcing a refresh from the browser."""
+    global _cached_catalog
+
+    if not INDEX_MODE_ENABLED:
+        return {
+            "abbreviated": [],
+            "full": [],
+            "metadata": {},
+            "catalog_version": None,
+            "index_mode_enabled": False,
+            "error": None,
+        }
+
+    if refresh or _cached_catalog is None:
+        try:
+            raw = vnc.get_element_catalog(refresh=refresh)
+        except Exception as exc:  # pragma: no cover - network failure
+            log.error("Failed to fetch element catalog: %s", exc)
+            return {
+                "abbreviated": [],
+                "full": [],
+                "metadata": {},
+                "catalog_version": None,
+                "index_mode_enabled": True,
+                "error": {"message": str(exc)},
+            }
+        _cached_catalog = _normalize_catalog(raw)
+    return _cached_catalog or {
+        "abbreviated": [],
+        "full": [],
+        "metadata": {},
+        "catalog_version": None,
+        "index_mode_enabled": True,
+        "error": None,
+    }
+
+
+def get_expected_version() -> Optional[str]:
+    """Return the catalog version to send with executor requests."""
+    catalog = get_catalog(refresh=False)
+    return catalog.get("catalog_version")
+
+
+def format_catalog_for_prompt(catalog: Dict[str, Any]) -> str:
+    """Return a human-friendly string representation of the abbreviated catalog."""
+    entries: List[Dict[str, Any]] = catalog.get("abbreviated", [])
+    if not entries:
+        return "(No interactive elements detected in the current viewport)"
+
+    lines: List[str] = []
+    for item in entries:
+        index = item.get("index")
+        role = item.get("role") or item.get("tag") or "element"
+        primary = item.get("primary_label") or ""
+        secondary = item.get("secondary_label") or ""
+        section = item.get("section_hint") or ""
+        state = item.get("state_hint") or ""
+        href = item.get("href_short") or ""
+
+        label_parts = []
+        if primary:
+            label_parts.append(primary)
+        if secondary and secondary != primary:
+            label_parts.append(secondary)
+        label_text = " — ".join(label_parts) if label_parts else "(no label)"
+
+        hint_parts = []
+        if section:
+            hint_parts.append(f"section: {section}")
+        if state:
+            hint_parts.append(state)
+        if href:
+            hint_parts.append(href)
+        hints = f" ({'; '.join(hint_parts)})" if hint_parts else ""
+
+        lines.append(f"[{index}] {role}: {label_text}{hints}")
+
+    return "\n".join(lines)
+
+
+def get_catalog_for_prompt(refresh: bool = False) -> Dict[str, Any]:
+    """Convenience helper returning both catalog data and formatted prompt text."""
+    catalog = get_catalog(refresh=refresh)
+    prompt_text = format_catalog_for_prompt(catalog)
+    return {"catalog": catalog, "prompt_text": prompt_text}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the project root is on sys.path for absolute imports
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_element_catalog.py
+++ b/tests/test_element_catalog.py
@@ -1,0 +1,38 @@
+import pytest
+
+from agent.element_catalog import get_catalog_for_prompt, reset_cache, INDEX_MODE_ENABLED
+
+
+@pytest.mark.skipif(not INDEX_MODE_ENABLED, reason="Index mode disabled")
+def test_get_catalog_for_prompt_formats_entries(monkeypatch):
+    reset_cache()
+
+    def fake_get(refresh=False):
+        return {
+            "abbreviated": [
+                {
+                    "index": 0,
+                    "role": "button",
+                    "tag": "button",
+                    "primary_label": "送信",
+                    "secondary_label": "",
+                    "section_hint": "フォーム",
+                    "state_hint": "",
+                    "href_short": "",
+                }
+            ],
+            "full": [],
+            "metadata": {"url": "https://example.com", "title": "Example"},
+            "catalog_version": "abc123",
+            "index_mode_enabled": True,
+        }
+
+    monkeypatch.setattr("agent.element_catalog.vnc.get_element_catalog", fake_get)
+
+    info = get_catalog_for_prompt()
+    catalog = info["catalog"]
+    prompt_text = info["prompt_text"]
+
+    assert catalog["catalog_version"] == "abc123"
+    assert "[0]" in prompt_text
+    assert "button" in prompt_text

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,37 @@
+from agent.controller.prompt import build_prompt
+
+
+def test_build_prompt_includes_catalog_section():
+    prompt = build_prompt(
+        cmd="ボタンをクリック",
+        page="<html><body><button>送信</button></body></html>",
+        hist=[],
+        screenshot=False,
+        elements=None,
+        error=None,
+        element_catalog_text="[0] button: 送信",
+        catalog_metadata={
+            "catalog_version": "v1",
+            "metadata": {"url": "https://example.com"},
+            "index_mode_enabled": True,
+        },
+    )
+
+    assert "catalog_version: v1" in prompt
+    assert "index=N" in prompt
+    assert "[0] button: 送信" in prompt
+
+
+def test_build_prompt_when_index_disabled():
+    prompt = build_prompt(
+        cmd="テスト",
+        page="<html></html>",
+        hist=[],
+        screenshot=False,
+        elements=None,
+        error=None,
+        element_catalog_text="",
+        catalog_metadata={"index_mode_enabled": False},
+    )
+
+    assert "INDEX_MODE が無効" in prompt


### PR DESCRIPTION
## Summary
- generate and expose a structured element catalog from the automation server with catalog versioning, index resolution, and new DSL actions for refresh/scroll/wait
- update the agent to fetch the catalog during observation, steer the LLM with catalog-aware prompt guidance, and forward expected catalog versions to Playwright
- add helper actions plus unit tests covering catalog formatting and prompt output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca344e52608320bdee89e31b326243