### PR TITLE
Fix UnboundLocalError when refreshing element catalog

### DIFF
--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -2644,6 +2644,7 @@ async def _run_actions(actions: List[Dict], correlation_id: str = "") -> tuple[s
 # -------------------------------------------------- HTTP エンドポイント
 @app.post("/execute-dsl")
 def execute_dsl():
+    global _CURRENT_CATALOG_SIGNATURE
     correlation_id = str(uuid.uuid4())[:8]
     log.info("Starting DSL execution with correlation ID: %s", correlation_id)
 


### PR DESCRIPTION
## Summary
- declare `_CURRENT_CATALOG_SIGNATURE` as global inside `execute_dsl` so automatic catalog refresh can reuse the shared signature without raising `UnboundLocalError`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5725888c8320ac275f5804b22783