### PR TITLE
Add pydantic dependency to VNC Docker image

### DIFF
--- a/vnc/Dockerfile
+++ b/vnc/Dockerfile
@@ -12,7 +12,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # ---- Python ライブラリ -------------------------------------------------
-RUN pip install --no-cache-dir "playwright[all]==1.44.0" flask httpx jsonschema>=4.0 \
+RUN pip install --no-cache-dir \
+      "playwright[all]==1.44.0" \
+      flask \
+      httpx \
+      "jsonschema>=4.0" \
+      "pydantic>=2.5" \
   && playwright install --with-deps chromium
   
 


### PR DESCRIPTION
## Summary
- install pydantic alongside existing Python dependencies in the VNC Docker image so automation modules can import it
- reformat the pip install command to avoid shell redirection issues when specifying version bounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca77c5bf408320b80c92490e174abf