### PR TITLE
Normalize DSL targets before execution

### DIFF
--- a/tests/test_normalize_actions.py
+++ b/tests/test_normalize_actions.py
@@ -1,0 +1,57 @@
+import pytest
+
+from web.app import normalize_actions
+
+
+def _extract_targets(actions):
+    return [action.get("target") for action in actions]
+
+
+def test_normalize_actions_converts_index_dict():
+    actions = normalize_actions({
+        "actions": [
+            {"action": "click", "target": {"index": 21}},
+        ]
+    })
+
+    assert _extract_targets(actions) == ["index=21"]
+
+
+def test_normalize_actions_converts_css_dict():
+    actions = normalize_actions({
+        "actions": [
+            {"action": "click", "target": {"css": "button.submit"}},
+        ]
+    })
+
+    assert _extract_targets(actions) == ["css=button.submit"]
+
+
+def test_normalize_actions_converts_role_dict_with_name():
+    actions = normalize_actions({
+        "actions": [
+            {"action": "click", "target": {"role": "button", "text": "送信"}},
+        ]
+    })
+
+    assert _extract_targets(actions) == ['role=button[name="送信"]']
+
+
+def test_normalize_actions_joins_selector_list():
+    actions = normalize_actions({
+        "actions": [
+            {"action": "click", "target": ["css=button.primary", {"index": 3}]},
+        ]
+    })
+
+    assert _extract_targets(actions) == ["css=button.primary || index=3"]
+
+
+def test_normalize_actions_handles_direct_string_target():
+    actions = normalize_actions({
+        "actions": [
+            {"action": "click", "target": "css=a[href='/?p=1']"},
+        ]
+    })
+
+    assert _extract_targets(actions) == ["css=a[href='/?p=1']"]


### PR DESCRIPTION
## Summary
- convert structured selector data from LLM responses into legacy string-based targets before sending them to the automation server
- add normalization for selector lists and non-string values, including stable index handling
- add unit tests covering the new normalization logic

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca8f1bdde08320b7d6ace47d632501