### PR TITLE
Handle screenshot timeouts gracefully

### DIFF
--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -63,6 +63,7 @@ NAVIGATION_TIMEOUT = int(os.getenv("NAVIGATION_TIMEOUT", "30000"))  # ms  ナビ
 WAIT_FOR_SELECTOR_TIMEOUT = int(os.getenv("WAIT_FOR_SELECTOR_TIMEOUT", "5000"))  # ms  セレクタ待機
 MAX_RETRIES = int(os.getenv("MAX_RETRIES", "3"))
 LOCATOR_RETRIES = int(os.getenv("LOCATOR_RETRIES", "3"))
+SCREENSHOT_TIMEOUT = int(os.getenv("SCREENSHOT_TIMEOUT", "5000"))  # ms スクリーンショット猶予
 CDP_URL = "http://localhost:9222"
 # Use about:blank as the default start page to avoid unexpected navigation
 DEFAULT_URL = os.getenv("START_URL", "about:blank")
@@ -947,7 +948,11 @@ async def _save_debug_artifacts(correlation_id: str, error_context: str = "") ->
         # Save screenshot
         screenshot_path = os.path.join(DEBUG_DIR, f"{correlation_id}_screenshot.png")
         try:
-            screenshot = await PAGE.screenshot(type="png")
+            screenshot = await PAGE.screenshot(
+                type="png",
+                timeout=SCREENSHOT_TIMEOUT,
+                animations="disabled",
+            )
             with open(screenshot_path, "wb") as f:
                 f.write(screenshot)
         except Exception as e:
@@ -2952,7 +2957,13 @@ def screenshot():
         # Only initialize browser if it's not already healthy
         if not PAGE or not _run(_check_browser_health()):
             _run(_init_browser())
-        img = _run(PAGE.screenshot(type="png"))
+        img = _run(
+            PAGE.screenshot(
+                type="png",
+                timeout=SCREENSHOT_TIMEOUT,
+                animations="disabled",
+            )
+        )
         return Response(base64.b64encode(img), mimetype="text/plain")
     except Exception as e:
         log.error("screenshot error: %s", e)

--- a/vnc/config.py
+++ b/vnc/config.py
@@ -19,6 +19,7 @@ DEFAULTS: Dict[str, Any] = {
     "log_root": "runs",
     "headless": True,
     "screenshot_mode": "viewport",
+    "screenshot_timeout_ms": 5000,
 }
 
 
@@ -33,6 +34,7 @@ class RunConfig:
     log_root: Path = field(default_factory=lambda: Path(DEFAULTS["log_root"]))
     headless: bool = DEFAULTS["headless"]
     screenshot_mode: str = DEFAULTS["screenshot_mode"]
+    screenshot_timeout_ms: int = DEFAULTS["screenshot_timeout_ms"]
 
     @classmethod
     def from_mapping(cls, mapping: Dict[str, Any]) -> "RunConfig":
@@ -49,6 +51,7 @@ class RunConfig:
             log_root=Path(data["log_root"]),
             headless=bool(str(data["headless"]).lower() in {"true", "1", "yes"}),
             screenshot_mode=str(data["screenshot_mode"]),
+            screenshot_timeout_ms=int(data["screenshot_timeout_ms"]),
         )
 
 


### PR DESCRIPTION
## Summary
- add a configurable screenshot timeout and use it for manual and automatic captures
- make action logging resilient to screenshot failures instead of retrying the whole action
- bound screenshot duration in the automation server to avoid repeated 30s waits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa4994e588320aeefc0e9d667af66