### PR TITLE
Improve selector normalization and synchronize catalog cache

### DIFF
--- a/tests/test_element_catalog.py
+++ b/tests/test_element_catalog.py
@@ -1,6 +1,12 @@
 import pytest
 
-from agent.element_catalog import get_catalog_for_prompt, reset_cache, INDEX_MODE_ENABLED
+from agent.element_catalog import (
+    get_catalog_for_prompt,
+    get_expected_version,
+    reset_cache,
+    update_cache_from_signature,
+    INDEX_MODE_ENABLED,
+)
 
 
 @pytest.mark.skipif(not INDEX_MODE_ENABLED, reason="Index mode disabled")
@@ -36,3 +42,44 @@ def test_get_catalog_for_prompt_formats_entries(monkeypatch):
     assert catalog["catalog_version"] == "abc123"
     assert "[0]" in prompt_text
     assert "button" in prompt_text
+
+
+@pytest.mark.skipif(not INDEX_MODE_ENABLED, reason="Index mode disabled")
+def test_update_cache_from_signature_triggers_refresh(monkeypatch):
+    reset_cache()
+
+    catalogs = [
+        {
+            "abbreviated": [],
+            "full": [],
+            "metadata": {"catalog_version": "old-version"},
+            "catalog_version": "old-version",
+            "index_mode_enabled": True,
+        },
+        {
+            "abbreviated": [],
+            "full": [],
+            "metadata": {"catalog_version": "new-version"},
+            "catalog_version": "new-version",
+            "index_mode_enabled": True,
+        },
+    ]
+
+    call_count = {"value": 0}
+
+    def fake_get(refresh=False):
+        call_count["value"] += 1
+        index = 0 if call_count["value"] == 1 else 1
+        return catalogs[index]
+
+    monkeypatch.setattr("agent.element_catalog.vnc.get_element_catalog", fake_get)
+
+    assert get_expected_version() == "old-version"
+    assert call_count["value"] == 1
+
+    update_cache_from_signature({"catalog_version": "new-version"})
+
+    assert get_expected_version() == "new-version"
+    assert call_count["value"] == 2
+
+    reset_cache()


### PR DESCRIPTION
## Summary
- add a JavaScript selector stringifier so browser actions always lowercase string targets and extend approval checks to use it
- track the last observed element catalog version, invalidate cached data when the executor reports a newer signature, and reuse that hint on fetch failures
- update the VNC executor to propagate catalog-version updates from observations and add regression coverage for the cache refresh behavior

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cacb746a988320820cd62dd96c6098