### PR TITLE
Improve SmartLocator role and placeholder handling

### DIFF
--- a/tests/test_locator_utils.py
+++ b/tests/test_locator_utils.py
@@ -1,0 +1,116 @@
+import asyncio
+import types
+
+from vnc.locator_utils import (
+    SmartLocator,
+    _css_escape,
+    _extract_css_hint,
+    _parse_role_selector,
+)
+
+
+class DummyLocator:
+    def __init__(self, placeholder: str):
+        self._placeholder = placeholder
+        self.first = self
+
+    async def wait_for(self, *args, **kwargs):
+        return None
+
+    async def get_attribute(self, name: str):
+        if name == "placeholder":
+            return self._placeholder
+        return None
+
+
+def test_parse_role_selector_with_name():
+    assert _parse_role_selector('role=button[name="Submit"]') == ("button", "Submit")
+
+
+def test_parse_role_selector_without_name():
+    assert _parse_role_selector("role=textbox") == ("textbox", None)
+
+
+def test_parse_role_selector_invalid():
+    assert _parse_role_selector("role-button") is None
+
+
+def test_locate_by_placeholder_prefers_exact(monkeypatch):
+    placeholder = "Search"
+    page = types.SimpleNamespace()
+    locator = DummyLocator(placeholder)
+
+    def get_by_placeholder(value, exact=True):
+        assert exact is True
+        return locator
+
+    page.get_by_placeholder = get_by_placeholder
+
+    def fail_locator(selector):
+        raise AssertionError("should not use fallback")
+
+    page.locator = fail_locator
+
+    async def fake_try(self, candidate):
+        return candidate
+
+    monkeypatch.setattr(SmartLocator, "_try", fake_try)
+
+    smart = SmartLocator(page, "dummy")
+    result = asyncio.run(smart._locate_by_placeholder(placeholder))
+    assert result is locator
+
+
+def test_locate_by_placeholder_uses_fallback_on_mismatch(monkeypatch):
+    placeholder = 'Say "hi"'
+    page = types.SimpleNamespace()
+    selectors = []
+
+    def get_by_placeholder(value, exact=True):
+        assert exact is True
+        return DummyLocator("Mismatch")
+
+    page.get_by_placeholder = get_by_placeholder
+
+    def locator_factory(selector):
+        selectors.append(selector)
+        if selector.startswith("input"):
+            return DummyLocator(placeholder)
+        raise AssertionError("unexpected fallback selector")
+
+    page.locator = locator_factory
+
+    async def fake_try(self, candidate):
+        return candidate
+
+    monkeypatch.setattr(SmartLocator, "_try", fake_try)
+
+    smart = SmartLocator(page, "dummy")
+    result = asyncio.run(smart._locate_by_placeholder(placeholder))
+    assert result is not None
+    expected = f'input[placeholder="{_css_escape(placeholder)}"]'
+    assert selectors[0] == expected
+
+
+def test_css_fallbacks_skip_generic_when_hint_present(monkeypatch):
+    page = types.SimpleNamespace()
+
+    def fail_locator(selector):
+        raise AssertionError(f"should not request fallback {selector}")
+
+    page.locator = fail_locator
+
+    async def fail_try(self, candidate):
+        raise AssertionError("should not invoke _try for skipped fallbacks")
+
+    monkeypatch.setattr(SmartLocator, "_try", fail_try)
+
+    smart = SmartLocator(page, "dummy")
+    hint = _extract_css_hint("input[data-testid='foo']")
+    result = asyncio.run(smart._try_css_fallbacks("input[data-testid='foo']", hint))
+    assert result is None
+
+
+def test_extract_css_hint_placeholder():
+    hint = _extract_css_hint('textarea[placeholder="Write here"]')
+    assert hint.placeholder == "Write here"

--- a/vnc/locator_utils.py
+++ b/vnc/locator_utils.py
@@ -16,15 +16,74 @@ target に "css=btn || text=Next" のように "||" 区切りで複数の
 候補を与えると、左から順に試行する。
 """
 from __future__ import annotations
-import re, os
-from typing import Optional
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
 
 from playwright.async_api import Locator, Page
 
 LOCATOR_TIMEOUT = int(os.getenv("LOCATOR_TIMEOUT", "2000"))  # ms(8000)
 
+@dataclass
+class _CssSelectorHint:
+    tag: Optional[str]
+    attributes: Dict[str, str]
+
+    @property
+    def placeholder(self) -> Optional[str]:
+        return self.attributes.get("placeholder")
+
+    def uses_hint(self, candidate: str) -> bool:
+        if not self.attributes:
+            return True
+
+        normalized_candidate = candidate.lower().replace("\\'", "'").replace('\\"', '"')
+        for attr, value in self.attributes.items():
+            attr_lower = attr.lower()
+            if f"[{attr_lower}" in normalized_candidate:
+                return True
+            if value:
+                value_lower = value.lower()
+                if value_lower in normalized_candidate:
+                    return True
+        return False
+
+
+def _parse_role_selector(value: str) -> Optional[Tuple[str, Optional[str]]]:
+    match = re.fullmatch(
+        r"role=([a-z0-9_-]+)(?:\[name=(['\"])(.+?)\2\])?",
+        value,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None
+    role, _, name = match.groups()
+    return role, name
+
+
+def _extract_css_hint(selector: str) -> _CssSelectorHint:
+    tag_match = re.match(r"\s*([a-zA-Z][\w-]*)", selector)
+    tag = tag_match.group(1).lower() if tag_match else None
+
+    attributes: Dict[str, str] = {}
+    for attr, quote, value in re.findall(r"\[([\w:-]+)\s*=\s*(['\"])(.*?)\2\]", selector):
+        attributes[attr.lower()] = value
+
+    return _CssSelectorHint(tag=tag, attributes=attributes)
+
+
+def _css_escape(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("'", "\\'")
+        .replace("]", "\\]")
+    )
+
+
 class SmartLocator:
-    _ROLE = re.compile(r"^role=(\w+)\[name=['\"](.+?)['\"]]$", re.I)
 
     def __init__(self, page: Page, target: str) -> None:
         self.page = page
@@ -38,10 +97,10 @@ class SmartLocator:
         if t.startswith("text="):
             return await self._try(self.page.get_by_text(t[5:], exact=True))
         if t.startswith("role="):
-            m = self._ROLE.match(t)
-            if m:
-                role, name = m.groups()
-                return await self._try(self.page.get_by_role(role, name=name, exact=True))
+            parsed = _parse_role_selector(t)
+            if parsed:
+                role, name = parsed
+                return await self._locate_by_role(role, name)
         if t.startswith("xpath="):
             return await self._try(self.page.locator(t))
 
@@ -54,7 +113,7 @@ class SmartLocator:
         loc = await self._try(self.page.get_by_label(t, exact=True))
         if loc:
             return loc
-        loc = await self._try(self.page.locator(f"input[placeholder='{t}']"))
+        loc = await self._locate_by_placeholder(t)
         if loc:
             return loc
         # label text followed by input element
@@ -81,19 +140,58 @@ class SmartLocator:
         try:
             # Enhanced waiting strategy
             await loc.first.wait_for(state="attached", timeout=LOCATOR_TIMEOUT)
-            
+
             # Additional checks for interactive elements
             if await self._is_interactive_element(loc):
                 # For interactive elements, also ensure they're visible and enabled
                 await loc.first.wait_for(state="visible", timeout=LOCATOR_TIMEOUT)
-                
+
                 # For form elements, wait for them to be enabled
                 if await self._is_form_element(loc):
                     await self._wait_for_element_ready(loc, timeout=LOCATOR_TIMEOUT)
-            
+
             return loc
         except Exception:
             return None
+
+    async def _locate_by_role(self, role: str, name: Optional[str]) -> Optional[Locator]:
+        if name:
+            loc = await self._try(self.page.get_by_role(role, name=name, exact=True))
+            if loc:
+                return loc
+            loc = await self._try(self.page.get_by_role(role, name=name, exact=False))
+            if loc:
+                return loc
+        return await self._try(self.page.get_by_role(role))
+
+    async def _locate_by_placeholder(self, placeholder: str) -> Optional[Locator]:
+        if not placeholder:
+            return None
+
+        escaped = _css_escape(placeholder)
+        candidate_factories = [
+            lambda: self.page.get_by_placeholder(placeholder, exact=True),
+            lambda: self.page.locator(f'input[placeholder="{escaped}"]'),
+            lambda: self.page.locator(f'textarea[placeholder="{escaped}"]'),
+        ]
+
+        for factory in candidate_factories:
+            try:
+                candidate = factory()
+            except Exception:
+                continue
+
+            loc = await self._try(candidate)
+            if loc and await self._attribute_equals(loc, "placeholder", placeholder):
+                return loc
+        return None
+
+    async def _attribute_equals(self, loc: Locator, attribute: str, expected: str) -> bool:
+        try:
+            value = await loc.first.get_attribute(attribute)
+        except Exception:
+            return False
+        return value == expected
 
     async def _is_interactive_element(self, loc: Locator) -> bool:
         """Check if element is interactive (button, input, link, etc.)"""
@@ -167,19 +265,24 @@ class SmartLocator:
         # 明示プレフィクス
         if t.startswith("css="):
             original_selector = t[4:]
+            hint = _extract_css_hint(original_selector)
             loc = await self._try(self.page.locator(original_selector))
             if loc:
                 return loc
+            if hint.placeholder:
+                loc = await self._locate_by_placeholder(hint.placeholder)
+                if loc:
+                    return loc
             # Enhanced fallbacks for CSS selectors
-            return await self._try_css_fallbacks(original_selector)
-            
+            return await self._try_css_fallbacks(original_selector, hint)
+
         if t.startswith("text="):
             return await self._try(self.page.get_by_text(t[5:], exact=True))
         if t.startswith("role="):
-            m = self._ROLE.match(t)
-            if m:
-                role, name = m.groups()
-                return await self._try(self.page.get_by_role(role, name=name, exact=True))
+            parsed = _parse_role_selector(t)
+            if parsed:
+                role, name = parsed
+                return await self._locate_by_role(role, name)
         if t.startswith("xpath="):
             return await self._try(self.page.locator(t))
 
@@ -192,7 +295,7 @@ class SmartLocator:
         loc = await self._try(self.page.get_by_label(t, exact=True))
         if loc:
             return loc
-        loc = await self._try(self.page.locator(f"input[placeholder='{t}']"))
+        loc = await self._locate_by_placeholder(t)
         if loc:
             return loc
         # label text followed by input element
@@ -212,32 +315,40 @@ class SmartLocator:
             return loc
 
         # 最後に裸 CSS - with enhanced fallbacks
+        hint = _extract_css_hint(t)
         loc = await self._try(self.page.locator(t))
         if loc:
             return loc
-        return await self._try_css_fallbacks(t)
+        if hint.placeholder:
+            loc = await self._locate_by_placeholder(hint.placeholder)
+            if loc:
+                return loc
+        return await self._try_css_fallbacks(t, hint)
 
-    async def _try_css_fallbacks(self, selector: str) -> Optional[Locator]:
+    async def _try_css_fallbacks(
+        self, selector: str, hint: _CssSelectorHint
+    ) -> Optional[Locator]:
         """Try enhanced fallbacks for CSS selectors that commonly fail."""
-        
+
         # Checkbox fallbacks
         if "checkbox" in selector and "[value=" in selector:
             # Try simpler checkbox selectors
             fallbacks = [
                 "input[type=checkbox]:visible",
                 "input[type=checkbox]",
-                "[type=checkbox]:visible", 
+                "[type=checkbox]:visible",
                 "[type=checkbox]"
             ]
             for fallback in fallbacks:
+                if not hint.uses_hint(fallback):
+                    continue
                 loc = await self._try(self.page.locator(fallback))
                 if loc:
                     return loc
-        
-        # Button with aria-label fallbacks  
+
+        # Button with aria-label fallbacks
         if "button" in selector and "aria-label" in selector:
             # Extract aria-label value
-            import re
             match = re.search(r"aria-label=['\"]([^'\"]+)['\"]", selector)
             if match:
                 label_text = match.group(1)
@@ -250,10 +361,12 @@ class SmartLocator:
                     f"[role=button]:visible"
                 ]
                 for fallback in fallbacks:
+                    if not hint.uses_hint(fallback):
+                        continue
                     loc = await self._try(self.page.locator(fallback))
                     if loc:
                         return loc
-        
+
         # Dynamic index-based selectors fallbacks
         if "data-cl_cl_index" in selector or "[data-" in selector:
             # Try more general approaches for dynamic attributes
@@ -263,10 +376,12 @@ class SmartLocator:
                 "a[href]:visible"
             ]
             for fallback in fallbacks:
+                if not hint.uses_hint(fallback):
+                    continue
                 loc = await self._try(self.page.locator(fallback))
                 if loc:
                     return loc
-        
+
         # Input field fallbacks
         if "input" in selector:
             fallbacks = [
@@ -275,17 +390,20 @@ class SmartLocator:
                 "textarea:visible"
             ]
             for fallback in fallbacks:
+                if not hint.uses_hint(fallback):
+                    continue
                 loc = await self._try(self.page.locator(fallback))
                 if loc:
                     return loc
-        
+
         # General element type fallbacks
         if selector.startswith(("button", "input", "a", "div")):
             element_type = selector.split("[")[0].split(".")[0].split("#")[0]
             fallback = f"{element_type}:visible"
-            loc = await self._try(self.page.locator(fallback))
-            if loc:
-                return loc
-                
+            if hint.uses_hint(fallback):
+                loc = await self._try(self.page.locator(fallback))
+                if loc:
+                    return loc
+
         return None
 


### PR DESCRIPTION
## Summary
- parse role= selectors more flexibly and order get_by_role fallbacks to prefer exact name matches
- add placeholder-aware lookup helper with safe CSS escaping and hint-aware CSS fallback filtering
- add unit tests for role parsing, placeholder helper, and fallback hygiene mocks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb4be07f98832093622837cc698029