### PR TITLE
Ensure selector resolver respects high index selectors

### DIFF
--- a/tests/test_selector_resolver.py
+++ b/tests/test_selector_resolver.py
@@ -1,0 +1,103 @@
+import asyncio
+
+from automation.dsl import Selector
+from automation.dsl.resolution import ResolutionAttempt
+from vnc.selector_resolver import SelectorResolver
+
+
+class FakeCandidateLocator:
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+    async def element_handle(self):
+        return object()
+
+
+class FakeLocator:
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    async def count(self) -> int:
+        return self._count
+
+    def nth(self, index: int) -> FakeCandidateLocator:
+        return FakeCandidateLocator(index)
+
+
+class FakePage:
+    def __init__(self, locator: FakeLocator) -> None:
+        self._locator = locator
+
+    def get_by_text(self, text: str, exact: bool = False) -> FakeLocator:
+        return self._locator
+
+
+def test_resolver_prefers_candidate_matching_high_index(monkeypatch):
+    locator = FakeLocator(count=10)
+    page = FakePage(locator)
+    resolver = SelectorResolver(page)
+    selector = Selector(text="Target", index=8, priority=["text"])
+
+    async def fake_build_attempt(
+        self,
+        locator,
+        element,
+        selector,
+        *,
+        strategy,
+        ordinal=None,
+        ref_metrics=None,
+    ) -> ResolutionAttempt:
+        ord_value = ordinal if ordinal is not None else -1
+        return ResolutionAttempt(
+            selector=selector,
+            locator=locator,
+            element=element,
+            dom_path=f"path-{ord_value}",
+            text_digest=f"text-{ord_value}",
+            strategy=strategy,
+            score=1.0 if ord_value == selector.index else 0.0,
+            metadata={"ordinal": ord_value},
+        )
+
+    monkeypatch.setattr(SelectorResolver, "_build_attempt", fake_build_attempt)
+
+    resolved = asyncio.run(resolver.resolve(selector))
+
+    assert resolved.metadata["ordinal"] == selector.index
+
+
+def test_collect_from_locator_includes_index_outside_limit(monkeypatch):
+    locator = FakeLocator(count=10)
+    resolver = SelectorResolver(page=None)  # page is unused in this test
+    selector = Selector(css="#button", index=7)
+
+    async def fake_build_attempt(
+        self,
+        locator,
+        element,
+        selector,
+        *,
+        strategy,
+        ordinal=None,
+        ref_metrics=None,
+    ) -> ResolutionAttempt:
+        ord_value = ordinal if ordinal is not None else -1
+        return ResolutionAttempt(
+            selector=selector,
+            locator=locator,
+            element=element,
+            dom_path=f"/div[{ord_value}]",
+            text_digest=f"candidate-{ord_value}",
+            strategy=strategy,
+            score=float(ord_value),
+            metadata={"ordinal": ord_value},
+        )
+
+    monkeypatch.setattr(SelectorResolver, "_build_attempt", fake_build_attempt)
+
+    attempts = asyncio.run(resolver._collect_from_locator(locator, selector, "css"))
+
+    ordinals = sorted(attempt.metadata["ordinal"] for attempt in attempts)
+    assert selector.index in ordinals
+    assert ordinals.count(selector.index) == 1

--- a/vnc/selector_resolver.py
+++ b/vnc/selector_resolver.py
@@ -258,7 +258,11 @@ class SelectorResolver:
     ) -> List[ResolutionAttempt]:
         attempts: List[ResolutionAttempt] = []
         count = await locator.count()
-        for index in range(min(count, MAX_CANDIDATES_PER_STRATEGY)):
+        limit = min(count, MAX_CANDIDATES_PER_STRATEGY)
+        indices = list(range(limit))
+        if selector.index is not None and 0 <= selector.index < count and selector.index not in indices:
+            indices.append(selector.index)
+        for index in indices:
             candidate_locator = locator.nth(index)
             handle = await candidate_locator.element_handle()
             if handle is None:


### PR DESCRIPTION
## Summary
- ensure the selector resolver inspects the requested index even when it exceeds the default candidate sample
- add tests covering index-aware resolution so actions select the intended target

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb7332ebe083208398bfcf06ea5c9d