### PR TITLE
Ensure Flask web app imports agent package without PYTHONPATH

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -2,7 +2,15 @@ import os
 import json
 import logging
 import re
+import sys
+from pathlib import Path
 from typing import Any, Dict
+
+# Ensure the project root is importable without relying on PYTHONPATH
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 import requests
 from flask import (
     Flask,


### PR DESCRIPTION
## Summary
- adjust the Flask controller startup to add the project root to sys.path so the agent package can be imported without relying on PYTHONPATH

## Testing
- pytest -q *(fails: async tests require pytest-asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cd21135be0832094c4f962bd3754ef