### PR TITLE
Use typed DSL plan for automation execution

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -2,7 +2,7 @@ import os
 import json
 import logging
 import re
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 import requests
 from flask import (
     Flask,
@@ -37,6 +37,8 @@ from agent.element_catalog import (
     record_prompt_version,
     should_refresh_for_prompt,
 )
+from automation.dsl.models import ActionBase, Selector
+from automation.dsl.registry import registry
 from vnc.dependency_check import ensure_component_dependencies
 
 # --------------- Flask & Logger ----------------------------------
@@ -248,46 +250,715 @@ def _stringify_selector(selector: Any) -> str:
         return ""
 
 
+def _strip_quotes(value: str) -> str:
+    text = value.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        return text[1:-1]
+    return text
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"true", "yes", "1", "on"}:
+            return True
+        if text in {"false", "no", "0", "off"}:
+            return False
+    return None
+
+
+def _normalize_priority(values: Any) -> List[str]:
+    if isinstance(values, str):
+        values = [values]
+    result: List[str] = []
+    if isinstance(values, Sequence):
+        for item in values:
+            text = str(item).strip()
+            if text and text not in result:
+                result.append(text)
+    return result
+
+
+def _parse_selector_segment(segment: str) -> Tuple[Dict[str, Any], List[str]]:
+    data: Dict[str, Any] = {}
+    priority: List[str] = []
+    text = segment.strip()
+    if not text:
+        return data, priority
+    lowered = text.lower()
+    if lowered.startswith("css="):
+        data["css"] = text.split("=", 1)[1].strip()
+        priority.append("css")
+        return data, priority
+    if lowered.startswith("xpath="):
+        data["xpath"] = text.split("=", 1)[1].strip()
+        priority.append("xpath")
+        return data, priority
+    if lowered.startswith("text="):
+        data["text"] = _strip_quotes(text.split("=", 1)[1])
+        priority.append("text")
+        return data, priority
+    if lowered.startswith("role="):
+        match = re.match(r"role=([^\[\]]+)(?:\[(name\*?=)\"([^\"]*)\"\])?", text)
+        if match:
+            data["role"] = match.group(1).strip()
+            priority.append("role")
+            if match.group(3):
+                data["text"] = match.group(3)
+                if "text" not in priority:
+                    priority.append("text")
+            return data, priority
+        data["role"] = text.split("=", 1)[1].strip()
+        priority.append("role")
+        return data, priority
+    if lowered.startswith("aria-label=") or lowered.startswith("aria_label="):
+        data["aria_label"] = _strip_quotes(text.split("=", 1)[1])
+        priority.append("aria_label")
+        return data, priority
+    if lowered.startswith("near_text=") or lowered.startswith("near-text="):
+        data["near_text"] = _strip_quotes(text.split("=", 1)[1])
+        priority.append("near_text")
+        return data, priority
+    if lowered.startswith("stable_id=") or lowered.startswith("stable-id="):
+        data["stable_id"] = _strip_quotes(text.split("=", 1)[1])
+        priority.append("stable_id")
+        return data, priority
+    if lowered.startswith("index="):
+        idx = _coerce_int(text.split("=", 1)[1])
+        if idx is not None and idx >= 0:
+            data["index"] = idx
+            priority.append("index")
+        return data, priority
+    data["css"] = text
+    priority.append("css")
+    return data, priority
+
+
+def _normalize_selector_string(value: str) -> Optional[Dict[str, Any]]:
+    text = value.strip()
+    if not text:
+        return None
+    parts = [part.strip() for part in text.split("||") if part.strip()]
+    combined: Dict[str, Any] = {}
+    priority: List[str] = []
+    for part in parts:
+        fields, segment_priority = _parse_selector_segment(part)
+        for key, val in fields.items():
+            if key == "index":
+                if "index" not in combined:
+                    combined["index"] = val
+            elif key not in combined:
+                combined[key] = val
+        for entry in segment_priority:
+            if entry not in priority:
+                priority.append(entry)
+    if priority:
+        combined["priority"] = priority
+    return combined or None
+
+
+def _normalize_selector_value(value: Any) -> Optional[Dict[str, Any] | Selector]:
+    if value is None:
+        return None
+    if isinstance(value, Selector):
+        return value
+    if isinstance(value, dict):
+        normalized: Dict[str, Any] = {}
+        if "selector" in value and len(value) == 1:
+            return _normalize_selector_value(value["selector"])
+        mapping = {
+            "css": "css",
+            "xpath": "xpath",
+            "text": "text",
+            "role": "role",
+            "aria_label": "aria_label",
+            "aria-label": "aria_label",
+            "ariaLabel": "aria_label",
+            "near_text": "near_text",
+            "nearText": "near_text",
+            "stable_id": "stable_id",
+            "stableId": "stable_id",
+            "stable-id": "stable_id",
+        }
+        for source, target in mapping.items():
+            if source in value and value[source] is not None:
+                normalized[target] = value[source]
+        if "index" in value:
+            idx = _coerce_int(value.get("index"))
+            if idx is not None and idx >= 0:
+                normalized["index"] = idx
+        if "priority" in value:
+            normalized["priority"] = _normalize_priority(value["priority"])
+        if "selector" in value:
+            nested = _normalize_selector_value(value["selector"])
+            if isinstance(nested, Selector):
+                return nested
+            if isinstance(nested, dict):
+                for key, val in nested.items():
+                    if key not in normalized:
+                        normalized[key] = val
+        if "name" in value and "text" not in normalized and value["name"] is not None:
+            normalized["text"] = value["name"]
+        if "label" in value and "text" not in normalized and value["label"] is not None:
+            normalized["text"] = value["label"]
+        return normalized or None
+    if isinstance(value, list):
+        combined: Dict[str, Any] = {}
+        priority: List[str] = []
+        for item in value:
+            nested = _normalize_selector_value(item)
+            if isinstance(nested, Selector):
+                nested = nested.model_dump(exclude_none=True)
+            if isinstance(nested, dict):
+                for key, val in nested.items():
+                    if key == "priority":
+                        for entry in val:
+                            if entry not in priority:
+                                priority.append(entry)
+                    elif key not in combined:
+                        combined[key] = val
+        if priority:
+            combined["priority"] = priority
+        return combined or None
+    if isinstance(value, str):
+        return _normalize_selector_string(value)
+    return None
+
+
+def _build_selector(value: Any) -> Optional[Selector]:
+    normalized = _normalize_selector_value(value)
+    if normalized is None:
+        return None
+    if isinstance(normalized, Selector):
+        return normalized
+    try:
+        return Selector.model_validate(normalized)
+    except Exception:
+        return None
+
+
+def _normalize_wait_state(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    mapping = {
+        "networkidle": "networkidle",
+        "network_idle": "networkidle",
+        "network-idle": "networkidle",
+        "load": "load",
+        "domcontentloaded": "domcontentloaded",
+        "dom_content_loaded": "domcontentloaded",
+        "dom-content-loaded": "domcontentloaded",
+        "visible": "visible",
+        "hidden": "hidden",
+        "attached": "attached",
+        "detached": "detached",
+    }
+    return mapping.get(text)
+
+
+def _normalize_assert_state(value: Any) -> str:
+    state = _normalize_wait_state(value)
+    if state in {"visible", "hidden", "attached", "detached"}:
+        return state
+    return "visible"
+
+
+def _build_wait_condition(condition: Any, fallback: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if condition is None:
+        return None
+    if isinstance(condition, Selector):
+        return {"selector": condition, "state": "visible"}
+    if isinstance(condition, dict):
+        if "selector" in condition or "target" in condition:
+            selector_value = condition.get("selector") or condition.get("target")
+            selector = _build_selector(selector_value)
+            if selector is None:
+                return None
+            state = _normalize_wait_state(condition.get("state") or condition.get("visibility"))
+            if not state:
+                state = "visible"
+            return {"selector": selector, "state": state}
+        cond_type = condition.get("type") or condition.get("kind")
+        if cond_type:
+            normalized_type = str(cond_type).strip().lower()
+            if normalized_type in {"selector", "element"}:
+                selector_value = (
+                    condition.get("selector")
+                    or condition.get("target")
+                    or fallback.get("target")
+                )
+                selector = _build_selector(selector_value)
+                if selector is None:
+                    return None
+                state = _normalize_wait_state(condition.get("state") or condition.get("visibility"))
+                if not state:
+                    state = "visible"
+                return {"selector": selector, "state": state}
+            if normalized_type in {"state", "load_state"}:
+                state = _normalize_wait_state(condition.get("state") or condition.get("value"))
+                if state in {"load", "domcontentloaded", "networkidle"}:
+                    return {"state": state}
+            if normalized_type in {"timeout", "delay"}:
+                timeout_val = _coerce_int(
+                    condition.get("timeout_ms")
+                    or condition.get("value")
+                    or condition.get("ms")
+                )
+                if timeout_val is not None:
+                    return {"timeout_ms": max(0, timeout_val)}
+        state = _normalize_wait_state(condition.get("state") or condition.get("value"))
+        if state in {"load", "domcontentloaded", "networkidle"}:
+            return {"state": state}
+        timeout_val = _coerce_int(
+            condition.get("timeout_ms") or condition.get("ms") or condition.get("value")
+        )
+        if timeout_val is not None:
+            return {"timeout_ms": max(0, timeout_val)}
+        nested = condition.get("for") or condition.get("condition") or condition.get("until")
+        if nested is not None:
+            return _build_wait_condition(nested, fallback)
+    if isinstance(condition, str):
+        normalized = condition.strip().lower().replace("-", "_")
+        if normalized in {"load", "domcontentloaded", "dom_content_loaded", "networkidle", "network_idle"}:
+            state = _normalize_wait_state(normalized)
+            if state:
+                return {"state": state}
+        if normalized in {"selector", "element"}:
+            selector = _build_selector(
+                fallback.get("selector") or fallback.get("target") or fallback.get("value")
+            )
+            if selector is None:
+                return None
+            state = _normalize_wait_state(fallback.get("state") or fallback.get("visibility"))
+            if not state:
+                state = "visible"
+            return {"selector": selector, "state": state}
+        if normalized in {"timeout", "time", "sleep"}:
+            timeout_val = _coerce_int(
+                fallback.get("timeout_ms") or fallback.get("ms") or fallback.get("value")
+            )
+            if timeout_val is not None:
+                return {"timeout_ms": max(0, timeout_val)}
+    if isinstance(condition, (int, float)):
+        return {"timeout_ms": max(0, int(condition))}
+    return None
+
+
+def _parse_scroll_target(value: Any) -> Optional[Any]:
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        lowered = text.lower()
+        if lowered in {"top", "bottom"}:
+            return lowered
+        amount = _coerce_int(text)
+        if amount is not None:
+            return amount
+        selector = _build_selector(text)
+        if selector:
+            return {"selector": selector}
+    if isinstance(value, dict):
+        target_selector = _build_selector(value.get("selector") or value.get("target"))
+        container_selector = _build_selector(value.get("container"))
+        axis = value.get("axis") if value.get("axis") in {"vertical", "horizontal", "both"} else None
+        align = value.get("align") if value.get("align") in {"start", "center", "end", "nearest"} else None
+        behavior = value.get("behavior") if value.get("behavior") in {"auto", "instant", "smooth"} else None
+        payload: Dict[str, Any] = {}
+        if target_selector:
+            payload["selector"] = target_selector
+        if container_selector:
+            payload["container"] = container_selector
+        if axis:
+            payload["axis"] = axis
+        if align:
+            payload["align"] = align
+        if behavior:
+            payload["behavior"] = behavior
+        return payload or None
+    if isinstance(value, list):
+        for item in value:
+            parsed = _parse_scroll_target(item)
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _prepare_wait_action(raw: Dict[str, Any], *, force_selector: bool = False) -> Dict[str, Any]:
+    prepared: Dict[str, Any] = {"action": "wait"}
+    timeout_val = _coerce_int(raw.get("timeout_ms") or raw.get("ms") or raw.get("value"))
+    if timeout_val is not None and timeout_val >= 0:
+        prepared["timeout_ms"] = timeout_val
+    condition_source = raw.get("for") or raw.get("condition")
+    if condition_source is None:
+        condition_source = raw.get("until")
+    condition_payload = _build_wait_condition(condition_source, raw)
+    if force_selector and condition_payload is None:
+        selector = _build_selector(raw.get("selector") or raw.get("target") or raw.get("value"))
+        if selector:
+            state = _normalize_wait_state(raw.get("state") or raw.get("visibility"))
+            if not state:
+                state = "visible"
+            condition_payload = {"selector": selector, "state": state}
+    if condition_payload:
+        if "selector" in condition_payload and "state" not in condition_payload:
+            condition_payload["state"] = "visible"
+        prepared["for"] = condition_payload
+    return prepared
+
+
+def _coerce_keys(keys_value: Any, single_key: Any) -> List[str]:
+    keys: List[str] = []
+    if isinstance(keys_value, list):
+        for item in keys_value:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                keys.append(text)
+    elif isinstance(keys_value, str):
+        keys = [part.strip() for part in keys_value.split("+") if part.strip()]
+    elif keys_value is not None:
+        text = str(keys_value).strip()
+        if text:
+            keys.append(text)
+    if not keys and single_key:
+        if isinstance(single_key, str):
+            keys = [part.strip() for part in single_key.split("+") if part.strip()]
+        else:
+            text = str(single_key).strip()
+            if text:
+                keys.append(text)
+    return keys
+
+
+def _prepare_action(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    action_name = str(raw.get("action") or raw.get("type") or "").strip().lower()
+    if not action_name:
+        return None
+
+    if action_name == "navigate":
+        url = raw.get("url") or raw.get("target")
+        if not url:
+            return None
+        prepared: Dict[str, Any] = {"action": "navigate", "url": str(url)}
+        wait_for = raw.get("wait_for")
+        wait_condition = _build_wait_condition(wait_for, raw) if wait_for is not None else None
+        if wait_condition:
+            prepared["wait_for"] = wait_condition
+        return prepared
+
+    if action_name in {"click", "click_text"}:
+        selector_source = raw.get("selector") or raw.get("target")
+        if action_name == "click_text":
+            text_value = raw.get("text") or selector_source
+            if text_value:
+                selector_source = {"text": text_value, "priority": ["text"]}
+        selector = _build_selector(selector_source)
+        if selector is None:
+            return None
+        prepared = {"action": "click", "selector": selector}
+        button_value = raw.get("button")
+        if button_value:
+            button_text = str(button_value).strip().lower()
+            if button_text in {"left", "right", "middle"}:
+                prepared["button"] = button_text
+        click_count = _coerce_int(raw.get("click_count") or raw.get("clicks") or raw.get("count"))
+        if click_count is not None and click_count > 1:
+            prepared["click_count"] = click_count
+        delay = _coerce_int(raw.get("delay_ms") or raw.get("delay"))
+        if delay is not None and delay >= 0:
+            prepared["delay_ms"] = delay
+        return prepared
+
+    if action_name == "hover":
+        selector = _build_selector(raw.get("selector") or raw.get("target"))
+        if selector is None:
+            return None
+        return {"action": "hover", "selector": selector}
+
+    if action_name == "type":
+        selector = _build_selector(raw.get("selector") or raw.get("target"))
+        if selector is None:
+            return None
+        text_value = raw.get("text")
+        if text_value is None:
+            text_value = raw.get("value") or ""
+        prepared = {"action": "type", "selector": selector, "text": str(text_value)}
+        press_enter = _coerce_bool(raw.get("press_enter") or raw.get("enter"))
+        if press_enter is not None:
+            prepared["press_enter"] = press_enter
+        clear_flag = _coerce_bool(raw.get("clear"))
+        if clear_flag is not None:
+            prepared["clear"] = clear_flag
+        return prepared
+
+    if action_name in {"select_option", "select"}:
+        selector = _build_selector(raw.get("selector") or raw.get("target"))
+        if selector is None:
+            return None
+        value = raw.get("value")
+        if value is None:
+            value = raw.get("label") or raw.get("option") or raw.get("text")
+        if value is None:
+            return None
+        return {"action": "select", "selector": selector, "value_or_label": str(value)}
+
+    if action_name == "press_key":
+        keys = _coerce_keys(raw.get("keys") or raw.get("hotkeys"), raw.get("key"))
+        if not keys:
+            return None
+        prepared = {"action": "press_key", "keys": keys}
+        scope_value = raw.get("scope") or raw.get("target_scope")
+        if scope_value:
+            scope_text = str(scope_value).strip().lower()
+            if scope_text in {"active_element", "page"}:
+                prepared["scope"] = scope_text
+        return prepared
+
+    if action_name == "wait":
+        return _prepare_wait_action(raw)
+
+    if action_name == "wait_for_selector":
+        return _prepare_wait_action(raw, force_selector=True)
+
+    if action_name == "scroll":
+        prepared: Dict[str, Any] = {"action": "scroll"}
+        container = _build_selector(raw.get("container") or raw.get("target"))
+        if container:
+            prepared["container"] = container
+        to_payload = _parse_scroll_target(raw.get("to"))
+        if to_payload is None:
+            amount = raw.get("amount")
+            if amount is None:
+                amount = raw.get("value")
+            to_payload = _parse_scroll_target(amount)
+        if to_payload is not None:
+            prepared["to"] = to_payload
+        else:
+            direction_value = raw.get("direction")
+            if direction_value:
+                direction_text = str(direction_value).strip().lower()
+                if direction_text in {"up", "down"}:
+                    prepared["direction"] = direction_text
+        return prepared
+
+    if action_name == "scroll_to_text":
+        text_value = raw.get("text") or raw.get("target") or raw.get("value")
+        if text_value is None:
+            return None
+        return {"action": "scroll_to_text", "text": str(text_value)}
+
+    if action_name == "eval_js":
+        script = raw.get("script") or raw.get("value")
+        if script is None:
+            return None
+        return {"action": "eval_js", "script": str(script)}
+
+    if action_name == "click_blank_area":
+        return {"action": "click_blank_area"}
+
+    if action_name == "close_popup":
+        return {"action": "close_popup"}
+
+    if action_name == "refresh_catalog":
+        return {"action": "refresh_catalog"}
+
+    if action_name == "stop":
+        reason = raw.get("reason") or "user_intervention"
+        message = raw.get("message") or ""
+        return {"action": "stop", "reason": str(reason), "message": str(message)}
+
+    if action_name == "screenshot":
+        prepared = {"action": "screenshot"}
+        mode_value = raw.get("mode")
+        mode = str(mode_value).strip().lower() if isinstance(mode_value, str) else None
+        if mode in {"viewport", "full", "full_page", "fullpage", "element"}:
+            prepared["mode"] = "full" if mode in {"full_page", "fullpage"} else mode
+        elif _coerce_bool(raw.get("full_page")):
+            prepared["mode"] = "full"
+        else:
+            prepared["mode"] = "viewport"
+        selector_source = raw.get("selector")
+        if selector_source is None and prepared["mode"] == "element":
+            selector_source = raw.get("target")
+        selector = _build_selector(selector_source)
+        if selector:
+            prepared["selector"] = selector
+            prepared["mode"] = "element"
+        file_name = raw.get("file_name") or raw.get("filename")
+        if file_name:
+            prepared["file_name"] = str(file_name)
+        return prepared
+
+    if action_name in {"extract_text", "extract"}:
+        selector = _build_selector(raw.get("selector") or raw.get("target"))
+        if selector is None:
+            return None
+        attr_value = raw.get("attr") or raw.get("attribute")
+        attr_text = str(attr_value).strip().lower() if attr_value else "text"
+        attr_mapping = {
+            "text": "text",
+            "inner_text": "text",
+            "innertext": "text",
+            "value": "value",
+            "href": "href",
+            "html": "html",
+            "inner_html": "html",
+            "innerhtml": "html",
+        }
+        attr = attr_mapping.get(attr_text, "text")
+        return {"action": "extract", "selector": selector, "attr": attr}
+
+    if action_name == "assert":
+        selector = _build_selector(raw.get("selector") or raw.get("target"))
+        if selector is None:
+            return None
+        state = _normalize_assert_state(raw.get("state"))
+        return {"action": "assert", "selector": selector, "state": state}
+
+    if action_name == "switch_tab":
+        target_data = raw.get("target") or raw.get("tab") or {}
+        if not isinstance(target_data, dict):
+            target_data = {"strategy": "index", "value": target_data}
+        strategy = str(
+            target_data.get("strategy")
+            or target_data.get("by")
+            or target_data.get("type")
+            or ""
+        ).strip().lower()
+        if not strategy:
+            if "index" in target_data:
+                strategy = "index"
+            elif "url" in target_data:
+                strategy = "url"
+            elif "title" in target_data:
+                strategy = "title"
+            elif "direction" in target_data:
+                strategy = str(target_data["direction"]).strip().lower()
+        if strategy in {"previous", "next", "latest"}:
+            target_payload = {"strategy": strategy}
+        else:
+            if strategy not in {"index", "url", "title"}:
+                strategy = "index"
+            value = target_data.get("value")
+            if strategy == "index":
+                if value is None:
+                    value = target_data.get("index")
+                value = _coerce_int(value)
+                if value is None:
+                    value = 0
+            elif strategy == "url":
+                if value is None:
+                    value = target_data.get("url")
+                if value is not None:
+                    value = str(value)
+            elif strategy == "title":
+                if value is None:
+                    value = target_data.get("title")
+                if value is not None:
+                    value = str(value)
+            target_payload = {"strategy": strategy}
+            if value is not None:
+                target_payload["value"] = value
+        return {"action": "switch_tab", "target": target_payload}
+
+    if action_name == "focus_iframe":
+        target_data = raw.get("target") or raw.get("frame") or {}
+        if not isinstance(target_data, dict):
+            target_data = {"strategy": "index", "value": target_data}
+        strategy = str(
+            target_data.get("strategy")
+            or target_data.get("by")
+            or target_data.get("type")
+            or ""
+        ).strip().lower()
+        if not strategy:
+            if "index" in target_data:
+                strategy = "index"
+            elif "name" in target_data:
+                strategy = "name"
+            elif "url" in target_data:
+                strategy = "url"
+            elif "selector" in target_data or "target" in target_data:
+                strategy = "element"
+            elif str(target_data).lower() in {"parent", "root"}:
+                strategy = str(target_data).lower()
+        if strategy in {"parent", "root"}:
+            target_payload = {"strategy": strategy}
+        else:
+            if strategy not in {"index", "name", "url", "element"}:
+                strategy = "index"
+            value = target_data.get("value")
+            if strategy == "index":
+                if value is None:
+                    value = target_data.get("index")
+                value = _coerce_int(value)
+                if value is None:
+                    value = 0
+            elif strategy == "name":
+                if value is None:
+                    value = target_data.get("name")
+                if value is not None:
+                    value = str(value)
+            elif strategy == "url":
+                if value is None:
+                    value = target_data.get("url")
+                if value is not None:
+                    value = str(value)
+            elif strategy == "element":
+                selector = _build_selector(target_data.get("selector") or target_data.get("target"))
+                value = selector if selector else None
+            target_payload = {"strategy": strategy}
+            if value is not None:
+                target_payload["value"] = value
+        return {"action": "focus_iframe", "target": target_payload}
+
+    return None
+
+
 def normalize_actions(llm_response):
-    """Extract and normalize actions from LLM response (optimized for speed)."""
+    """Parse LLM output into typed DSL actions."""
     if not llm_response:
         return []
-    
+
     actions = llm_response.get("actions", [])
     if not isinstance(actions, list):
         return []
-    
-    # Optimized normalization using list comprehension for speed
-    normalized = []
+
+    parsed: List[ActionBase] = []
     for action in actions:
         if not isinstance(action, dict):
             continue
-            
-        # Create normalized action with proper lowercasing
-        normalized_action = dict(action)  # Start with copy
-        
-        # Normalize action name to lowercase
-        if "action" in normalized_action:
-            normalized_action["action"] = str(normalized_action["action"]).lower()
-        
-        # Handle selector -> target mapping (optimized)
-        if "selector" in action and "target" not in action:
-            normalized_action["target"] = action["selector"]
-            
-        # Handle click_text action (optimized)
-        elif (normalized_action.get("action") == "click_text" and
-              "text" in action and "target" not in action):
-            normalized_action["target"] = action["text"]
+        prepared = _prepare_action(action)
+        if not prepared:
+            continue
+        try:
+            parsed_action = registry.parse_action(prepared)
+        except Exception as exc:
+            log.debug("Failed to parse action %s: %s", prepared.get("action"), exc)
+            continue
+        parsed.append(parsed_action)
+    return parsed
 
-        if "target" in normalized_action:
-            normalized_action["target"] = _stringify_selector(normalized_action["target"])
 
-        if "value" in normalized_action and not isinstance(normalized_action["value"], str):
-            normalized_action["value"] = str(normalized_action["value"])
-
-        normalized.append(normalized_action)
-
-    return normalized
 
 
 @app.route("/history", methods=["GET"])
@@ -459,7 +1130,12 @@ def execute():
     
     # Extract and normalize actions from LLM response
     actions = normalize_actions(res)
-    uses_catalog_indices = bool(actions) and is_catalog_enabled() and actions_use_catalog_indices(actions)
+    legacy_actions = [action.legacy_payload() for action in actions]
+    uses_catalog_indices = (
+        bool(legacy_actions)
+        and is_catalog_enabled()
+        and actions_use_catalog_indices(legacy_actions)
+    )
     if uses_catalog_indices:
         log.debug("Planned actions rely on catalog indices")
 
@@ -472,14 +1148,15 @@ def execute():
             task_id = executor.create_task()
 
             # Start Playwright execution in parallel (immediate submission)
-            payload_extra = {}
+            plan_payload = {"actions": [action.payload(by_alias=True) for action in actions]}
+            payload_extra: Dict[str, Any] = {"plan": plan_payload, "run_id": task_id}
             if is_catalog_enabled() and expected_catalog_version:
                 payload_extra["expected_catalog_version"] = expected_catalog_version
             success = executor.submit_playwright_execution(
                 task_id,
                 execute_dsl,
-                actions,
-                payload=payload_extra or None,
+                legacy_actions,
+                payload=payload_extra,
             )
             
             if success:


### PR DESCRIPTION
## Summary
- parse LLM output into typed DSL actions and construct plan payloads in the web executor
- include plan metadata and run identifiers when dispatching automation tasks
- allow the VNC DSL endpoint to accept plan-based payloads and derive legacy feedback data

## Testing
- python -m compileall automation agent web

------
https://chatgpt.com/codex/tasks/task_e_68ce1c6b10788320adf277eb9c60fc7c