### PR TITLE
Sanitize executor payload parsing and add regression test

### DIFF
--- a/vnc/executor.py
+++ b/vnc/executor.py
@@ -590,7 +590,16 @@ class RunExecutor:
 
     def _parse_payload(self, payload: Dict[str, Any]) -> RunRequest:
         if "plan" in payload:
-            return RunRequest.model_validate(payload)
+            plan_value = payload.get("plan")
+            sanitized: Dict[str, Any] = {
+                "run_id": payload.get("run_id") or f"run-{int(time.time())}",
+                "plan": plan_value,
+            }
+            if "config" in payload:
+                sanitized["config"] = payload["config"]
+            if "metadata" in payload:
+                sanitized["metadata"] = payload["metadata"]
+            return RunRequest.model_validate(sanitized)
         actions = payload.get("actions", [])
         plan = []
         for action in actions:

--- a/vnc/tests/test_executor.py
+++ b/vnc/tests/test_executor.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from automation.dsl import NavigateAction
+from vnc.executor import RunExecutor
+
+
+def test_parse_payload_ignores_extra_fields() -> None:
+    executor = RunExecutor(page=MagicMock())
+    payload = {
+        "run_id": "test-run",
+        "plan": {
+            "actions": [
+                {
+                    "type": "navigate",
+                    "url": "https://example.com",
+                }
+            ]
+        },
+        "actions": [
+            {
+                "type": "click",
+                "selector": {"css": "button"},
+            }
+        ],
+        "expected_catalog_version": "1.0.0",
+    }
+
+    request = executor._parse_payload(payload)
+
+    assert request.run_id == "test-run"
+    assert len(request.plan.actions) == 1
+    action = request.plan.actions[0]
+    assert isinstance(action, NavigateAction)
+    assert action.url == "https://example.com"


### PR DESCRIPTION
## Summary
- sanitize `_parse_payload` to validate only expected fields
- add regression coverage to ensure plan actions are parsed when extra payload fields are provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce287ee324832084aeb17578366ad4