### PR TITLE
Fix index collector signature to accept ref_metrics

### DIFF
--- a/vnc/selector_resolver.py
+++ b/vnc/selector_resolver.py
@@ -232,8 +232,15 @@ class SelectorResolver:
         locator = self.page.get_by_label(selector.aria_label, exact=False)
         return await self._collect_from_locator(locator, selector, "aria_label", ref_metrics=ref_metrics)
 
-    async def _collect_index(self, selector: Selector) -> List[ResolutionAttempt]:
+    async def _collect_index(
+        self,
+        selector: Selector,
+        *,
+        ref_metrics: Optional[Dict[str, Any]] = None,
+    ) -> List[ResolutionAttempt]:
         # Index acts as a filter on previous results; handled in scoring.
+        # The ref_metrics argument is accepted for interface parity with other
+        # collectors but is not used.
         return []
 
     async def _collect_generic(


### PR DESCRIPTION
## Summary
- allow the index collector to accept the ref_metrics parameter so it matches other selector strategies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce2b9eebbc8320ad4811dec64f3a3c