### PR TITLE
Add annotated catalog overlays and clarify browser vision prompt

### DIFF
--- a/vnc/requirements.txt
+++ b/vnc/requirements.txt
@@ -1,5 +1,6 @@
 flask
 httpx
 jsonschema>=4.0
+Pillow
 playwright==1.44.0
 pydantic>=2.5

--- a/web/app.py
+++ b/web/app.py
@@ -387,7 +387,12 @@ def execute():
         return jsonify(error="command empty"), 400
 
     page = data.get("pageSource") or vnc_html()
-    shot = data.get("screenshot")
+    raw_screenshot = data.get("screenshot")
+    screenshot_payload = None
+    if isinstance(raw_screenshot, str):
+        trimmed = raw_screenshot.strip()
+        if trimmed:
+            screenshot_payload = trimmed if trimmed.startswith("data:image") else f"data:image/png;base64,{trimmed}"
     model = data.get("model", "gemini")
     prev_error = data.get("error")
     hist = load_hist()
@@ -444,15 +449,15 @@ def execute():
         cmd,
         page,
         hist,
-        bool(shot),
+        bool(screenshot_payload),
         elements,
         err_msg,
         element_catalog_text=catalog_prompt_text,
         catalog_metadata=catalog_data,
     )
-    
+
     # Call LLM first
-    res = call_llm(prompt, model, shot)
+    res = call_llm(prompt, model, screenshot_payload)
 
     # Save conversation history immediately with current URL
     append_history_entry(cmd, res, current_url)

--- a/web/static/browser_executor.js
+++ b/web/static/browser_executor.js
@@ -31,7 +31,14 @@ async function captureScreenshot() {
         console.error("screenshot fetch failed:", response.status, await response.text());
         return null;
     }
-    return await response.text(); // base64エンコードされたデータURIを返す
+    const payload = (await response.text()).trim();
+    if (!payload) {
+        return null;
+    }
+    if (payload.startsWith("data:image")) {
+        return payload;
+    }
+    return `data:image/png;base64,${payload}`;
 
   } catch (e) {
     console.error("screenshot error:", e);


### PR DESCRIPTION
## Summary
- draw catalog bounding boxes and index labels onto the Playwright screenshot response so the automation server returns annotated imagery
- ensure the web client forwards the annotated screenshot as a data URI and normalize it before calling the LLM
- update the system prompt with a <browser_vision> block that explains how to cross-reference the annotated screenshot with the catalog indices

## Testing
- python -m compileall agent web vnc

------
https://chatgpt.com/codex/tasks/task_e_68ce73fd802883209e6e0b8721fa0ecd