### PR TITLE
Fix PYTHONPATH for dependency check

### DIFF
--- a/vnc/Dockerfile
+++ b/vnc/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /opt
 COPY . /opt/vnc
 
 # 依存関係が正しくインストールされていることをビルド時に検証
-ENV PYTHONPATH=/opt
+ENV PYTHONPATH=/opt/vnc:/opt
 RUN python -m vnc.dependency_check --component vnc
 
 # ② 既存パス互換のためエントリポイントにシンボリックリンクを張る


### PR DESCRIPTION
## Summary
- ensure the VNC image build points Python at the copied source tree so dependency checks can import the package

## Testing
- not run (docker not available in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ce7b53aa94832082c603564b6c7a20