### PR TITLE
Revamp DOM summary and browser DSL actions

### DIFF
--- a/agent/actions/basic.py
+++ b/agent/actions/basic.py
@@ -65,3 +65,74 @@ def eval_js(script: str) -> Dict:
     by the automation server and can be fetched with :func:`get_eval_results`.
     """
     return {"action": "eval_js", "script": script}
+
+
+def search_google(query: str, new_tab: bool = False) -> Dict:
+    return {"action": "search_google", "query": query, "new_tab": new_tab}
+
+
+def go_to_url(url: str, new_tab: bool = False) -> Dict:
+    return {"action": "go_to_url", "target": url, "new_tab": new_tab}
+
+
+def click_element_by_index(index: int, ctrl: bool | None = None) -> Dict:
+    act = {"action": "click_element_by_index", "index": index}
+    if ctrl is not None:
+        act["while_holding_ctrl"] = ctrl
+    return act
+
+
+def input_text(index: int, text: str, clear_existing: bool = True) -> Dict:
+    return {
+        "action": "input_text",
+        "index": index,
+        "text": text,
+        "clear_existing": clear_existing,
+    }
+
+
+def scroll_pages(down: bool = True, num_pages: float = 1.0, frame_index: int | None = None) -> Dict:
+    act: Dict = {"action": "scroll", "down": down, "num_pages": num_pages}
+    if frame_index is not None:
+        act["frame_element_index"] = frame_index
+    return act
+
+
+def scroll_to_text(text: str) -> Dict:
+    return {"action": "scroll_to_text", "text": text}
+
+
+def send_keys(keys: str) -> Dict:
+    return {"action": "send_keys", "keys": keys}
+
+
+def switch_tab(tab_id: str) -> Dict:
+    return {"action": "switch_tab", "tab_id": tab_id}
+
+
+def close_tab(tab_id: str | None = None) -> Dict:
+    act = {"action": "close_tab"}
+    if tab_id:
+        act["tab_id"] = tab_id
+    return act
+
+
+def get_dropdown_options(index: int) -> Dict:
+    return {"action": "get_dropdown_options", "index": index}
+
+
+def select_dropdown_option(index: int, text: str) -> Dict:
+    return {"action": "select_dropdown_option", "index": index, "text": text}
+
+
+def upload_file_to_element(index: int, path: str | list[str]) -> Dict:
+    return {"action": "upload_file_to_element", "index": index, "path": path}
+
+
+def extract_structured_data(index: int | None = None, target: str | None = None) -> Dict:
+    act: Dict = {"action": "extract_structured_data"}
+    if index is not None:
+        act["index"] = index
+    if target:
+        act["target"] = target
+    return act

--- a/agent/browser/dom.py
+++ b/agent/browser/dom.py
@@ -5,129 +5,142 @@ from typing import Dict, List, Optional
 
 
 @dataclass
-class DOMElementNode:
-    tagName: str = ""
-    attributes: Dict[str, str] = field(default_factory=dict)
-    text: Optional[str] = None
-    xpath: str = ""
-    isVisible: bool = False
-    isInteractive: bool = False
-    isTopElement: bool = False
-    highlightIndex: Optional[int] = None
-    children: List["DOMElementNode"] = field(default_factory=list)
+class DOMRect:
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
 
     @classmethod
-    def from_json(cls, data: dict) -> "DOMElementNode":
-        if data is None:
-            return None
-        if data.get("nodeType") == "text":
-            return cls(tagName="#text", text=data.get("text"))
-        children = [cls.from_json(c) for c in data.get("children", []) if c]
+    def from_json(cls, data: Dict | None) -> "DOMRect":
+        if not isinstance(data, dict):
+            return cls()
+        try:
+            return cls(
+                x=int(data.get("x", 0)),
+                y=int(data.get("y", 0)),
+                width=int(data.get("width", 0)),
+                height=int(data.get("height", 0)),
+            )
+        except Exception:
+            return cls()
+
+
+@dataclass
+class DOMElementSummary:
+    index: int
+    tag: str
+    text: str
+    attributes: Dict[str, str] = field(default_factory=dict)
+    rect: DOMRect = field(default_factory=DOMRect)
+    ancestors: List[str] = field(default_factory=list)
+    is_interactive: bool = False
+    is_scrollable: bool = False
+
+    @classmethod
+    def from_json(cls, data: Dict) -> "DOMElementSummary":
+        attrs_raw = data.get("attributes")
+        attrs: Dict[str, str] = {}
+        if isinstance(attrs_raw, dict):
+            for key, value in attrs_raw.items():
+                if key == "data" and isinstance(value, dict):
+                    for dkey, dval in value.items():
+                        if dval is not None:
+                            attrs[f"data-{dkey}"] = str(dval)
+                elif value is not None:
+                    attrs[str(key)] = str(value)
+        ancestors = [str(a) for a in data.get("ancestors", []) if a]
         return cls(
-            tagName=data.get("tagName", ""),
-            attributes=data.get("attributes", {}),
-            text=data.get("text"),
-            xpath=data.get("xpath", ""),
-            isVisible=data.get("isVisible", False),
-            isInteractive=data.get("isInteractive", False),
-            isTopElement=data.get("isTopElement", False),
-            highlightIndex=data.get("highlightIndex"),
-            children=children,
+            index=int(data.get("index", 0)),
+            tag=str(data.get("tag", "")),
+            text=str(data.get("text", "")),
+            attributes=attrs,
+            rect=DOMRect.from_json(data.get("rect")),
+            ancestors=ancestors,
+            is_interactive=bool(data.get("isInteractive", False)),
+            is_scrollable=bool(data.get("isScrollable", False)),
         )
 
+    def short_attributes(self) -> str:
+        keys = [
+            "id",
+            "name",
+            "role",
+            "type",
+            "value",
+            "placeholder",
+            "aria-label",
+            "href",
+            "title",
+        ]
+        parts = [f"{k}={self.attributes[k]}" for k in keys if self.attributes.get(k)]
+        if not parts:
+            data_keys = [k for k in self.attributes if k.startswith("data-")]
+            parts.extend(f"{k}={self.attributes[k]}" for k in data_keys[:2])
+        return ", ".join(parts)
+
+    def to_prompt_line(self) -> str:
+        info = self.short_attributes()
+        label = self.text.strip()
+        if len(label) > 80:
+            label = f"{label[:80]}…"
+        base = f"[{self.index:03d}] <{self.tag}>{' ' + label if label else ''}"
+        if info:
+            base += f" | {info}"
+        if self.is_scrollable:
+            base += " | scrollable"
+        if self.ancestors:
+            base += " | parents: " + " > ".join(self.ancestors[:3])
+        base += (
+            f" | ({self.rect.x},{self.rect.y}) {self.rect.width}x{self.rect.height}"
+        )
+        return base
+
+
+@dataclass
+class DOMSnapshot:
+    title: str = ""
+    url: str = ""
+    elements: List[DOMElementSummary] = field(default_factory=list)
+    summary_lines: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
     @classmethod
-    def from_html(cls, html: str) -> "DOMElementNode":
-        """Parse raw HTML into a simplified DOMElementNode tree."""
-        from bs4 import BeautifulSoup, NavigableString, Tag
+    def from_json(cls, data: Dict) -> "DOMSnapshot":
+        elements_data = data.get("elements") or []
+        elements = [
+            DOMElementSummary.from_json(el)
+            for el in elements_data
+            if isinstance(el, dict)
+        ]
+        summary_raw = data.get("summary")
+        if isinstance(summary_raw, str):
+            summary_lines = [line for line in summary_raw.splitlines() if line.strip()]
+        elif isinstance(summary_raw, list):
+            summary_lines = [str(line) for line in summary_raw]
+        else:
+            summary_lines = []
+        return cls(
+            title=str(data.get("title", "")),
+            url=str(data.get("url", "")),
+            elements=elements,
+            summary_lines=summary_lines,
+            error=str(data.get("error")) if data.get("error") else None,
+        )
 
-        soup = BeautifulSoup(html, "html.parser")
-        # Remove <script> and <style> tags entirely to keep the DOM concise
-        for t in soup.find_all(["script", "style"]):
-            t.decompose()
+    def to_text(self, limit: int | None = None) -> str:
+        header = []
+        if self.url:
+            header.append(f"URL: {self.url}")
+        if self.title:
+            header.append(f"Title: {self.title}")
+        if self.error:
+            header.append(f"Warning: {self.error}")
 
-        counter = 1
-        interactive_tags = {
-            "a",
-            "button",
-            "input",
-            "select",
-            "textarea",
-            "option",
-        }
-
-        def get_xpath(el: Tag) -> str:
-            parts = []
-            while el and isinstance(el, Tag):
-                idx = 1
-                sib = el.previous_sibling
-                while sib:
-                    if isinstance(sib, Tag) and sib.name == el.name:
-                        idx += 1
-                    sib = sib.previous_sibling
-                parts.append(f"{el.name}[{idx}]")
-                el = el.parent
-            return "/" + "/".join(reversed(parts))
-
-        def traverse(node) -> Optional[DOMElementNode]:
-            nonlocal counter
-            if isinstance(node, NavigableString):
-                text = str(node).strip()
-                if not text:
-                    return None
-                return cls(tagName="#text", text=text)
-            if not isinstance(node, Tag):
-                return None
-            if node.name in {"script", "style"}:
-                return None
-
-            children = [c for c in (traverse(ch) for ch in node.children) if c]
-            attrs = {
-                k: (" ".join(v) if isinstance(v, list) else str(v))
-                for k, v in node.attrs.items()
-            }
-
-            xpath = get_xpath(node)
-            interactive = node.name in interactive_tags
-            hidx = counter if interactive else None
-            if interactive:
-                counter += 1
-
-            return cls(
-                tagName=node.name,
-                attributes=attrs,
-                xpath=xpath,
-                isVisible=True,
-                isInteractive=interactive,
-                isTopElement=interactive,
-                highlightIndex=hidx,
-                children=children,
-            )
-
-        root = soup.body or soup
-        return traverse(root)
-
-    def to_lines(
-        self, depth: int = 0, max_lines: int | None = 200, _lines=None
-    ) -> List[str]:
-        """Return indented text representation of the DOM tree."""
-        if _lines is None:
-            _lines = []
-        if max_lines is not None and len(_lines) >= max_lines:
-            return _lines
-        indent = "  " * depth
-        if self.tagName == "#text":
-            if self.text and self.text.strip():
-                _lines.append(f"{indent}{self.text.strip()}")
-            return _lines
-        attr = " ".join(f"{k}={v}" for k, v in self.attributes.items() if v)
-        idx = f" [{self.highlightIndex}]" if self.highlightIndex is not None else ""
-        line = f"{indent}<{self.tagName}{(' ' + attr) if attr else ''}>{idx}"
-        _lines.append(line)
-        for ch in self.children:
-            if max_lines is not None and len(_lines) >= max_lines:
-                break
-            ch.to_lines(depth + 1, max_lines, _lines)
-        return _lines
-
-    def to_text(self, max_lines: int | None = 200) -> str:
-        return "\n".join(self.to_lines(max_lines=max_lines))
+        body_lines: List[str]
+        if self.summary_lines:
+            body_lines = self.summary_lines[: limit or len(self.summary_lines)]
+        else:
+            elems = self.elements[: limit or len(self.elements)]
+            body_lines = [el.to_prompt_line() for el in elems]
+        return "\n".join(header + body_lines)

--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -1,338 +1,149 @@
-import os
 import logging
+import os
+from typing import Iterable
+
+from ..browser.dom import DOMSnapshot
 from ..utils.html import strip_html
-from ..browser.dom import DOMElementNode
 
 log = logging.getLogger("controller")
 MAX_STEPS = int(os.getenv("MAX_STEPS", "10"))
 
 
-def _collect_interactive(node: DOMElementNode, lst: list):
-    if node.highlightIndex is not None:
-        lst.append(node)
-    for ch in getattr(node, "children", []):
-        _collect_interactive(ch, lst)
+def _format_history(hist: Iterable[dict]) -> str:
+    lines: list[str] = []
+    for entry in hist:
+        user = entry.get("user", "")
+        bot = entry.get("bot", {}) or {}
+        explanation = bot.get("explanation", "")
+        if user or explanation:
+            lines.append(f"U:{user}")
+            lines.append(f"A:{explanation}")
+    return "\n".join(lines) if lines else "(履歴なし)"
+
+
+def _format_error(error: str | list | None) -> str:
+    if not error:
+        return ""
+    if isinstance(error, list):
+        lines: list[str] = []
+        for item in error:
+            lines.extend(str(item).splitlines())
+    else:
+        lines = str(error).splitlines()
+    keywords = (
+        "error",
+        "timeout",
+        "not found",
+        "exception",
+        "traceback",
+        "fail",
+    )
+    filtered = [line for line in lines if any(k in line.lower() for k in keywords)]
+    selected = filtered[-10:] if filtered else lines[-10:]
+    return "\n".join(selected)
 
 
 def build_prompt(
     cmd: str,
-    page: str,
+    snapshot: DOMSnapshot | None,
     hist,
     screenshot: bool = False,
-    elements: DOMElementNode | list | None = None,
-    error: str | None = None,
+    error: str | list | None = None,
+    raw_html: str | None = None,
 ) -> str:
-    """Return full system prompt for the LLM."""
-    past_conv = "\n".join(f"U:{h['user']}\nA:{h['bot']['explanation']}" for h in hist)
+    """Return the full system prompt for the LLM."""
 
+    past_conv = _format_history(hist)
     add_img = (
-        "現在の状況を把握するために、スクリーンショット画像も与えます。"
+        "スクリーンショット画像が添付されています。"
         if screenshot
-        else ""
+        else "スクリーンショットは今回提供されません。"
     )
-    elem_lines = ""
-    error_line = ""
-    if error:
-        if isinstance(error, list):
-            err_lines: list[str] = []
-            for e in error:
-                err_lines.extend(str(e).splitlines())
+
+    dom_text: str
+    if snapshot:
+        dom_text = snapshot.to_text(limit=160)
+    else:
+        fallback = strip_html(raw_html or "")
+        dom_text = fallback[:4000] if fallback else "(DOMサマリーの取得に失敗しました)"
+
+    if snapshot and snapshot.error:
+        if error:
+            error = f"{error}\n{snapshot.error}"
         else:
-            err_lines = str(error).splitlines()
-        # Extract only meaningful error lines. Previously the keyword list
-        # contained "visible" which caused verbose Playwright logs such as
-        # "waiting for locator ... to be visible" to be captured and drown out
-        # actual error messages (e.g. timeouts).  Narrowing the keywords to
-        # genuine error indicators ensures `error_line` reflects real
-        # failures like "Timeout exceeded" or "Element is not visible".
-        keywords = (
-            "error",
-            "timeout",
-            "not found",
-            "traceback",
-            "exception",
-            "warning",
-            "not visible",
-        )
-        lines = [l for l in err_lines if any(k in l.lower() for k in keywords)]
-        if lines:
-            error_line = "\n".join(lines[-10:]) + "\n--------------------------------\n"
-    dom_text = strip_html(page)
-    if elements:
-        nodes: list[DOMElementNode] = []
-        if isinstance(elements, DOMElementNode):
-            _collect_interactive(elements, nodes)
-            dom_text = elements.to_text(max_lines=None)
-        elif isinstance(elements, list):
-            for n in elements:
-                if isinstance(n, DOMElementNode):
-                    _collect_interactive(n, nodes)
-        nodes.sort(key=lambda x: x.highlightIndex or 0)
-        elem_lines = "\n".join(
-            f"[{n.highlightIndex}] <{n.tagName}> {n.text or ''} id={n.attributes.get('id')} class={n.attributes.get('class')}"
-            for n in nodes
-        )
+            error = snapshot.error
+    error_line = _format_error(error)
+
+    instructions = f"""
+あなたはブラウザタスクを自動化するAIエージェントです。ユーザーの最終目的を満たすために、慎重に観察し、論理的に行動を選択してください。
+
+### 思考プロセス
+1. **観察**: DOMサマリーと会話履歴から現在の状況を正確に把握してください。
+2. **思考**: 目的達成までの最短経路を計画し、同じ失敗を繰り返さないようにします。
+3. **行動決定**: 必要な操作を Playwright 互換の DSL(JSON) で出力してください。
+
+### DOMサマリーの読み方
+- 各行は `[番号] <tag> ...` 形式で、番号がインデックスです。操作する場合は必ずこの番号を `click_element_by_index` などのアクションに指定してください。
+- `selector hint` は補助的なロケータ候補です。インデックスが最優先で、ヒントは代替案を考える際にのみ参照してください。
+- `scrollable` が付いた要素はスクロール可能なコンテナを示します。`scroll` アクションで `frame_element_index` にその番号を指定することで内部スクロールが可能です。
+
+### 出力フォーマット
+1. 最初に日本語で、状況の説明・取得した情報・次の方針を200〜300文字程度で記述してください。
+2. 続けて ```json フェンス内に以下形式でDSLを出力してください。
+   ```json
+   {{
+     "actions": [ ... ],
+     "complete": false
+   }}
+   ```
+- `actions` が空の場合は `complete` を必ず `true` にし、タスク完了理由を説明文で述べます。
+- JSON以外の不要な文字列は出力しないでください。
+
+### 利用可能なアクション
+- `{{"action": "search_google", "query": "検索語", "new_tab": false}}`
+- `{{"action": "go_to_url", "target": "https://...", "new_tab": false}}`
+- `{{"action": "click_element_by_index", "index": 12, "while_holding_ctrl": false}}`
+- `{{"action": "input_text", "index": 15, "text": "入力内容", "clear_existing": true}}` (index 0 でページ全体へのタイプ)
+- `{{"action": "wait", "ms": 1000}}`
+- `{{"action": "scroll", "down": true, "num_pages": 0.5, "frame_element_index": 34}}`
+- `{{"action": "scroll_to_text", "text": "探したい文字列"}}`
+- `{{"action": "send_keys", "keys": "Control+L"}}`
+- `{{"action": "switch_tab", "tab_id": "00a1"}}`
+- `{{"action": "close_tab", "tab_id": "00a1"}}`
+- `{{"action": "get_dropdown_options", "index": 27}}`
+- `{{"action": "select_dropdown_option", "index": 27, "text": "表示テキスト"}}`
+- `{{"action": "upload_file_to_element", "index": 31, "path": "/path/to/file"}}`
+- `{{"action": "extract_structured_data", "index": 40}}` または `target` をCSSで指定
+- `{{"action": "wait_for_selector", "target": "css=...", "ms": 3000}}`
+- `{{"action": "go_back"}}`, `{{"action": "go_forward"}}`, `{{"action": "hover", "target": "css=..."}}`, `{{"action": "press_key", "key": "Enter", "target": "css=..."}}`, `{{"action": "extract_text", "target": "css=..."}}`, `{{"action": "eval_js", "script": "..."}}`
+
+### 重要なルール
+- インデックスが付与された要素のみを直接操作してください。推測したセレクタで操作することは禁止です。
+- ページ遷移後は新たに表示されたDOMを確認してから次の操作を計画してください。
+- 同じ失敗を繰り返さず、必要に応じて `wait` や `scroll` を挿入して安定性を確保します。
+- ドロップダウンの内容が不明なときは `get_dropdown_options` を先に呼び出し、結果を説明文に反映させてから `select_dropdown_option` を実行してください。
+- タブ操作が必要な場合は `switch_tab` / `close_tab` を明示的に使用します。新しいタブで開く必要があるときは `click_element_by_index` の `while_holding_ctrl` か `go_to_url` / `search_google` の `new_tab` を活用してください。
+- `extract_structured_data` や `extract_text` で取得した情報は説明文に必ず反映します。
+- 最大 {MAX_STEPS} ステップ以内に目的を達成できない場合、残作業をまとめた上で `complete: true` を返してください。
+
+### 参考: DOMサマリー
+{dom_text}
+"""
 
     system_prompt = (
-        "あなたは、ブラウザタスクを自動化するために反復ループで動作するAIエージェントです。\n"
-        "最終的な目標は、ユーザーに命令されたタスクを達成することです。\n\n"
-        """
-    ** 基本的な思考プロセス**\n
-    ** あなたは行動を決定する前に、必ず以下の思考プロセスを内部的に実行してください。**\n
-    ** 1.  観察 (Observation): まず、現在のページのHTML情報やスクリーンショットを注意深く読み解きます。特に、直前の自分のアクションによってページがどのように変化したか（新しい要素は表示されたか、何かが消えたかなど）に注目します。**\n
-    ** 2.  思考 (Thought): 次に、観察結果とタスクの最終目標、過去の行動履歴を総合的に分析します。「このアクションはタスク完了に本当に貢献するだろうか？」「同じ行動の繰り返しになっていないか？」を常に自問自答してください。もしループに陥りそうだと判断したら、その原因を考え、全く異なるアプローチ（別のボタンをクリックする、テキスト入力を試みるなど）を検討します。**\n
-    ** 3.  行動決定 (Action Decision): 最後に、思考の結果として最も合理的だと判断したアクションをJSON形式で出力します。**\n
-    ** **\n\n
-    """
-        """あなたは以下のタスクに優れています: \n
-    1. 複雑なウェブサイトをナビゲートし、正確な情報を抽出する \n
-    2. フォームの送信とインタラクティブなウェブアクションを自動化する \n
-    3. Webサイトにアクセスして、情報を収集して保存する \n
-    4. ファイルシステムを効果的に使用して、コンテキストに何を保持するかを決定する\n
-    5. エージェントループで効果的に操作する \n
-    6. 多様なウェブタスクを効率的に実行する\n\n"""
-        """
-    各ステップで、次の状態が表示されます。\n
-    1. エージェント履歴: 以前のアクションとその結果を含む時系列のイベント ストリーム。これは部分的に省略される場合があります。\n
-    2. ユーザー リクエスト: これは最終目的で、常に表示されます。\n
-    3. エージェント状態: 現在の進行状況と関連するコンテキスト メモリ。\n
-    4. ブラウザ状態: 表示されているページ コンテンツ。\n\n
-
-    ユーザーリクエスト: これは最終的な目的であり、常に表示されます。\n
-        - これは最優先事項です。ユーザーを満足させましょう。\n
-        - ユーザーのリクエストは、各ステップを慎重に実行し、ステップを省略したり、誤解したりしないでください。\n
-        - タスクに期限がない場合は、それをどのように完了するかを自分でさらに計画することができます。\n\n
-        - "complete"を出す前に、ユーザーのリクエストが本当に完了したのかを確認する必要がある。結果をユーザーに返したり、結果のページを表示した状態になっているのかが重要。\n
-
-    成功するための役立つヒント：\n
-        - ポップアップ/Cookie は、承認または閉じることで対処します。\n
-        - スクロールして目的の要素を見つけます。\n
-        - 行き詰まった場合は、別の方法を試してください。\n
-        - 広告やプロモーションの内容はすべて無視してよいです。\n
-        - 重要：エラーやその他の失敗が発生した場合は、同じ操作を繰り返さないでください。\n
-        - 連続してエラーが発生したりループに陥ったと判断した場合は、ページを更新する・戻る・別の要素を試すなど、これまでと異なるアプローチを検討してください。\n
-        - フォームに入力する際は、必ず下にスクロールしてフォーム全体に入力してください。\n
-        - PDF が開いている場合は、PDF に関する質問に回答する必要があります。それ以外の場合、PDF を操作したり、ダウンロードしたり、ボタンを押したりすることはできません。\n
-        - ページ全体ではなく、ページ内のコンテナをスクロールする必要がある場合は、コンテナをクリックしてからキーを押し、水平方向にスクロールします。\n\n
-
-    ブラウザを使用して Web を閲覧する際は、以下のルールに厳密に従ってください。\n
-        - 数値の [インデックス] が割り当てられた要素のみを操作します。\n
-        - 調査が必要な場合は、関連のありそうなページ遷移して情報を取得してください。遷移するページ数に制限はありません。情報が取得できた、もしくは取得できそうにない場合には、作業をしていたページに戻ってください。\n
-
-        - 直前のステップと全く同じアクション（例：同じ要素に対する `click`）を繰り返してはなりません。**\n
-        - アクションを実行してもページに意味のある変化（新しい情報や要素の表示など）がなければ、そのアクションは「失敗」とみなし、次は必ず異なるアクションやアプローチを試してください。\n
-        - 【最重要】入力候補（サジェストリスト）への対処法:\n
-        - 状況の認識：入力フォームを操作した直後、そのフォームの近くにクリック可能な項目（`<a>`, `<li>`, `<div>`など）がリスト形式で新たに出現した場合、それは「入力候補リスト」であると強く推測してください。\n
-        - 推奨される行動：この「入力候補リスト」を認識した場合、以下のいずれかの行動をとってください。\n
-        - A) 候補から選択：リスト内に目的の項目があれば、その項目をクリックします。\n
-        - B) 操作を完了・継続：目的の項目がなければ、検索ボタンなどをクリックするか、テキスト入力を続けます。\n
-        - 禁止される行動：この状況で、再度もとの入力フォームを安易にクリックする行為は、無限ループに繋がるため避けてください。\n
-
-        - たとえば、テキスト入力アクションの後にページが変更された場合は、リストから適切なオプションを選択するなど、新しい要素を操作する必要があるかどうかを分析します。\n
-        - デフォルトでは、表示されているビューポート内の要素のみがリストされます。操作が必要なコンテンツが画面外にあると思われる場合は、スクロールツールを使用してください。ページの上下にピクセルが残っている場合にのみスクロールしてください。コンテンツ抽出アクションは、読み込まれたページコンテンツ全体を取得します。\n
-        - 必要な要素が見つからない場合は、更新、スクロール、または戻ってみてください。\n
-        - ページ遷移が予想されない場合には複数のアクションを使用します (例: 複数のフィールドに入力してから [送信] をクリックする)。\n
-        - ページが完全に読み込まれていない場合は、待機アクションを使用します。\n
-        - ページ遷移後は、必要に応じて `wait_for_selector` を使用して、目的の要素が表示されるまで待機してください。\n 
-        - 入力フィールドに入力してアクション シーケンスが中断された場合、ほとんどの場合、何かが変更されます (例: フィールドの下に候補がポップアップ表示されます)。\n
-        - ユーザーリクエストに商品の種類、評価、価格、所在地などの特定のページ情報が含まれている場合は、フィルターを適用して効率化を図ってください。フィルターオプションをすべて表示するには、スクロールする必要がある場合もあります。\n
-        - ユーザーリクエストが最終的な目標です。ユーザーが明示的に手順を指定した場合、その手順は常に最優先されます。\n
-        - ユーザーがページ内の特定のテキスト情報を求めている場合は、その情報を抽出して説明に含めて返すこと。\n
-
-    """
-        "|目的|\n"
-        "ユーザーの自然言語命令を受け取り、Playwright 互換の DSL(JSON) でブラウザ操作手順を生成します。\n"
-        "まず **現在表示されているページ(HTML ソースを渡します)** を必ず確認し、"
-        "さらに **ユーザーがページ内の具体的なテキスト情報を求めている場合は、その情報を抽出して説明に含めて返す** こと。\n"
-        "（例: 『開催概要を教えて』→ ページにある開催概要を説明文に貼り付ける）\n"
-        "\n"
-        "|出力フォーマット|\n"
-        "1 行目〜複数行 : 取得した情報や操作意図を日本語で説明。\n"
-        "    ユーザーが求めたページ内情報があれば **ここに要約または全文を含める**。\n"
-        "    80 文字制限は撤廃して良いが、最長 300 文字程度に収める。(jsonフェンス外のユーザーへの情報にはjsonを入れてはいけない)\n"
-        "その後に ```json フェンス内で DSL を出力。\n"
-        "\n"
-        "```json の中身は以下のフォーマット:\n"
-        "{\n"
-        '  "actions": [ <action_object> , ... ],\n'
-        '  "complete": true | false               # true ならタスク完了, false なら未完了で続行\n'
-        "}\n"
-        "\n"
-        "<action_object> は次のいずれか:\n"
-        '  { "action": "navigate",       "target": "https://example.com" }\n'
-        '  { "action": "click",          "target": "css=button.submit" }\n'
-        '  { "action": "click_text",     "text":   "次へ" }\n'
-        '  { "action": "type",           "target": "css=input[name=q]", "value": "検索ワード" }\n'
-        '  { "action": "wait",           "ms": 1000 }\n'
-        '  { "action": "scroll",         "target": "css=div.list", "direction": "down", "amount": 400 }\n'
-        '  { "action": "go_back" }\n'
-        '  { "action": "go_forward" }\n'
-        '  { "action": "hover",          "target": "css=div.menu" }\n'
-        '  { "action": "select_option",   "target": "css=select", "value": "option1" }\n'
-        '  { "action": "press_key",      "key": "Enter", "target": "css=input" }\n'
-        '  { "action": "wait_for_selector", "target": "css=button.ok", "ms": 3000 }\n'
-        '  { "action": "extract_text",    "target": "css=div.content" }\n'
-        '  { "action": "eval_js",        "script": "document.title" }\n\n\n'
-        "\n\n"
-        "|ルール|\n"
-        "1. 現ページで表示されている要素のみ操作してよい。ページ遷移後の要素の操作は、次のステップで生成しなくてはいけない。つまりページ遷移が必要かつ、複数のアクションがあった場合には、ページ遷移が最後のアクションである必要がある。\n"
-        "2. 与えられた情報にある要素のみ操作してよい。要素名を予想してアクションを生成することはしてはいけない。\n"
-        "3. 現ページで目的達成できる場合は `actions` を **空配列** で返し、`complete:true`。\n"
-        "4. `click` はCSSセレクタで指定します。**非表示要素(`aria-hidden='true'`など)を避け、ユニークな属性(id, name, data-testidなど)を優先してください。**\n"
-        "5. `click_text` は可視テキストで指定します。\n"
-        "6. 失敗しやすい操作には `wait` を挿入し、安定化を図ること。\n"
-        "7. 類似要素が複数ある場合は `:nth-of-type()` や `:has-text()` などで特定性を高める。\n"
-        "8. 一度に大量の操作を出さず、状況確認が必要な場合は `complete:false` とし段階的に進める。\n"
-        "9. 一度に有効な複数の操作を出す場合には、各アクションの間に0.5秒の待機を設ける\n"
-        "10. **ユーザーがページ内テキストを要求している場合**:\n"
-        "    - `navigate` や `click` を行わずとも情報が取れるなら `actions` は空。\n"
-        '    - 説明部にページから抽出したテキストを含める（長文は冒頭 200 文字＋"..."）。\n'
-        f"11. 最大 {MAX_STEPS} ステップ以内にタスクを完了できない場合は `complete:true` で終了してください。\n"
-        "\n"
-        "Python で利用できるアクションヘルパー関数:\n"
-        "#click: 指定したターゲットをクリックするアクション\n"
-        "  def click(target: str) -> Dict:\n"
-        '      return {"action": "click", "target": target}\n'
-        "#click_text: 指定したテキストを持つ要素をクリックするアクション\n"
-        "  def click_text(text: str) -> Dict:\n"
-        '      return {"action": "click_text", "text": text, "target": text}\n'
-        "# navigate: 指定した URL へナビゲートするアクション\n"
-        "  def navigate(url: str) -> Dict:\n"
-        '      return {"action": "navigate", "target": url}\n'
-        "# type_text: 指定したターゲットにテキストを入力するアクション\n"
-        "  def type_text(target: str, value: str) -> Dict:\n"
-        '      return {"action": "type", "target": target, "value": value}\n'
-        "# wait: 一定時間待機するアクション\n"
-        "  def wait(ms: int = 500, retry: int | None = None) -> Dict:\n"
-        '      act = {"action": "wait", "ms": ms}\n'
-        '      if retry is not None: act["retry"] = retry\n'
-        "      return act\n"
-        "# wait_for_selector: 指定したセレクタが出現するまで待機するアクション\n"
-        "  def wait_for_selector(target: str, ms: int = 3000) -> Dict:\n"
-        '      return {"action": "wait_for_selector", "target": target, "ms": ms}\n'
-        "# go_back: ブラウザの「戻る」操作を行うアクション\n"
-        "  def go_back() -> Dict:\n"
-        '      return {"action": "go_back"}\n'
-        "# go_forward: ブラウザの「進む」操作を行うアクション\n"
-        "  def go_forward() -> Dict:\n"
-        '      return {"action": "go_forward"}\n'
-        "# hover: 指定したターゲットにマウスカーソルを移動させるアクション\n"
-        "  def hover(target: str) -> Dict:\n"
-        '      return {"action": "hover", "target": target}\n'
-        "# select_option: セレクト要素から指定した値を選択するアクション\n"
-        "  def select_option(target: str, value: str) -> Dict:\n"
-        '      return {"action": "select_option", "target": target, "value": value}\n'
-        "# press_key: 指定したキーを押下するアクション\n"
-        "  def press_key(key: str, target: str | None = None) -> Dict:\n"
-        '      act = {"action": "press_key", "key": key}\n'
-        '      if target: act["target"] = target\n'
-        "      return act\n"
-        "# extract_text: 指定したターゲットからテキストを抽出するアクション\n"
-        "  def extract_text(target: str) -> Dict:\n"
-        '      return {"action": "extract_text", "target": target}\n'
-        "# eval_js: 任意の JavaScript を実行して結果を保存するアクション\n"
-        "  def eval_js(script: str) -> Dict:\n"
-        '      return {"action": "eval_js", "script": script}\n'
-        "#   DOM 状態の確認や動的値の取得に使い、戻り値は後から取得可能\n"
-        """
-    === ブラウザ操作 DSL 出力ルール（必読・厳守）================================
-    目的 : Playwright 側 /execute-dsl エンドポイントで 100% 受理・実行可能な
-            JSON を生成し、「locator not found」や Timeout を極小化すること。
-    制約 : 返答は **JSON オブジェクトのみ**。前後に Markdown・説明・改行・コードフェンス禁止。
-    
-    ========================================================================
-    1. トップレベル構造
-    {
-      "actions": [ <Action1>, <Action2>, ... ],   # 1‥30 件まで
-      "complete": true|false                      # 省略可（タスク完了なら true）
-    }
-    - `actions` だけは必須。追加プロパティは禁止（システムが許可していても出力しない）。\n
-    - JSON は UTF-8 / 無コメント / 最終要素に “,” を付けない。\n
-    ========================================================================
-    2. アクションは 14 種のみ\n
-    | action            | 必須キー                                   | 追加キー            | 説明                 |\n
-    |-------------------|--------------------------------------------|--------------------|----------------------|\n
-    | navigate          | target (URL)                              | —                  | URL へ遷移           |\n
-    | click             | target (CSS/XPath)                        | —                  | 要素クリック         |\n
-    | click_text        | target (完全一致文字列)                    | —                  | 可視文字列クリック   |\n
-    | type              | target, value                             | —                  | テキスト入力         |\n
-    | wait              | ms (整数≥0)                               | retry (整数)       | 指定 ms 待機         |\n
-    | scroll            | amount (整数), direction ("up"/"down")    | target (任意)      | スクロール           |\n
-    | go_back           | —                                         | —                  | ブラウザ戻る         |\n
-    | go_forward        | —                                         | —                  | ブラウザ進む         |\n
-    | hover             | target                                    | —                  | ホバー               |\n
-    | select_option     | target, value                             | —                  | ドロップダウン選択   |\n
-    | press_key         | key                                       | target (任意)      | キー送信             |\n
-    | wait_for_selector | target, ms                                | —                  | 要素待機             |\n
-    | extract_text      | target                                    | attr (任意)        | テキスト取得         |\n    | eval_js          | script                                   | —         | JavaScript 実行      |\n
-
-
-    **上記以外の action 名・キーは絶対に出力しない。**\n
-    ========================================================================
-    3. セレクタ設計ガイドライン\n
-    1. **安定属性優先**: `data-testid`, `aria-*`, `role=` を用いる。\n
-    2. **テキスト使用時**は `click_text` で完全一致文字列を渡す（前後空白と改行を除去）。\n
-    3. nth-of-type・動的 class 名・深い XPath は禁止。\n
-    4. SmartLocator が自動判別するため、接頭辞が無い場合は CSS として解釈される。\n
-    5. 1 アクションで失敗しそうな場合は、代替手段を別アクションとして続けて記述する。\n
-    ========================================================================
-    4. 安定実行のためのフロー指針\n
-    - ページ遷移直後は **必ず `wait`(ms≥1000) を挿入** し、描画完了を保証。  \n
-    - クリック後に要素が動的生成される UI では、次アクション前に適切な `wait` を使う。\n  
-    - スクロールは一度に `amount`≦400 で分割し、目標要素の近辺で止める。\n
-    - 同一要素への連続 `click` は 2 回まで。変化が無ければ方針転換する。\n
-    - 最大アクション数 30 を超えない。ループ検知時は `\"complete\": true` で終了。\n
-    - `pointer-events` に遮られたエラーが起きたら、`scroll` で位置調整→`wait`(300 ms)→再 `click` を 1 回だけ試し、それでも失敗したら次手段を選択する。
-
-    - アクション実行時にエラーが返された場合、その内容が次のプロンプトに提供されます。原因を推測し、別の要素を試す・ページ遷移するなど、より効果的な代替案を考えてください。
-    \n
-    ========================================================================
-    5. 禁止事項\n
-    - コメント・改行付き JSON、JSON5/JSONC 形式、配列単体の送信。\n  
-    - 定義外プロパティ（例: selectorType, force)、空文字列 target、null 値。\n  
-    - ユーザー説明文や “Here is the DSL:” など JSON 以外の出力。  \n
-    ========================================================================
-    6. 返答フォーマット例（**実際の返答は JSON 部分のみ**)\n
-        "{ \"actions\": [ { \"action\": \"navigate\", \"target\": \"https://example.com\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"click\", \"target\": \"css=button.submit\" } ], \"complete\": true }\n"
-        "{ \"actions\": [ { \"action\": \"click_text\", \"text\": \"次へ\", \"target\": \"次へ\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"type\", \"target\": \"css=input[name=q]\", \"value\": \"検索ワード\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"wait\", \"ms\": 1000 } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"wait\", \"ms\": 1000, \"retry\": 3 } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"wait_for_selector\", \"target\": \"css=button.ok\", \"ms\": 3000 } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"scroll\", \"direction\": \"down\", \"amount\": 400 } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"scroll\", \"target\": \"css=div.list\", \"direction\": \"up\", \"amount\": 200 } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"go_back\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"go_forward\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"hover\", \"target\": \"css=div.menu\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"select_option\", \"target\": \"css=select#country\", \"value\": \"JP\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"press_key\", \"key\": \"Enter\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"press_key\", \"key\": \"Tab\", \"target\": \"css=input[name=q]\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"extract_text\", \"target\": \"css=div.content\" } ], \"complete\": false }\n"
-        "{ \"actions\": [ { \"action\": \"eval_js\", \"script\": \"document.title\" } ], \"complete\": false }\n"
-        "{ \"actions\": [], \"complete\": true }\n"
-    ========================================================================
-    """
-        "\n"
-        "--------------------------------\n"
-        "---- 現在のページのDOMツリー ----\n"
-        f"{dom_text}\n"
-        "--------------------------------\n"
-        "## これまでの会話履歴\n"
-        f"{past_conv}\n"
-        "--------------------------------\n"
-        "## ユーザー命令\n"
-        f"{cmd}\n"
-        "--------------------------------\n"
-        "## 現在のブラウザの状況の画像\n"
-        f"{add_img}\n"
-        "## 現在のエラー状況\n"
-        f"{error_line}"
+        instructions
+        + "\n--------------------------------\n"
+        + "## これまでの会話履歴\n"
+        + f"{past_conv}\n"
+        + "--------------------------------\n"
+        + "## ユーザー命令\n"
+        + f"{cmd}\n"
+        + "--------------------------------\n"
+        + "## 追加情報\n"
+        + f"スクリーンショット: {add_img}\n"
     )
 
-    #"---- 操作候補要素一覧 (操作対象は番号で指定 & この一覧にない要素の操作も可能 あくまで参考) ----\n"
-    #f"{elem_lines}\n"
-    print(f"DOMツリー:{dom_text}")
-    print(f"エラー:{error_line}")
+    if error_line:
+        system_prompt += f"エラー: {error_line}\n"
 
     return system_prompt

--- a/agent/llm/client.py
+++ b/agent/llm/client.py
@@ -64,6 +64,38 @@ def _normalize_action(a: Dict) -> Dict:
     if act["action"] == "press_key" and "key" not in act:
         act["key"] = "Enter"
 
+    if act["action"] == "go_to_url" and "target" not in act and "url" in act:
+        act["target"] = act["url"]
+
+    if act["action"] == "click_element_by_index" and "index" in act:
+        try:
+            act["index"] = int(act["index"])
+        except Exception:
+            pass
+
+    if act["action"] == "input_text":
+        if "clear_existing" not in act:
+            act["clear_existing"] = True
+        if "index" in act:
+            try:
+                act["index"] = int(act["index"])
+            except Exception:
+                pass
+
+    if act["action"] == "scroll":
+        if "down" not in act and "direction" in act:
+            act["down"] = act["direction"].lower() != "up"
+        if "num_pages" in act:
+            try:
+                act["num_pages"] = float(act["num_pages"])
+            except Exception:
+                pass
+        if "frame_element_index" in act:
+            try:
+                act["frame_element_index"] = int(act["frame_element_index"])
+            except Exception:
+                pass
+
     return act
 
 

--- a/vnc/automation_server.py
+++ b/vnc/automation_server.py
@@ -6,6 +6,7 @@ import base64
 import json
 import logging
 import os
+import re
 import time
 from typing import Dict, List, Optional
 
@@ -13,7 +14,7 @@ from typing import Dict, List, Optional
 import httpx
 from flask import Flask, Response, jsonify, request
 from jsonschema import Draft7Validator, ValidationError
-from playwright.async_api import Error as PwError, async_playwright
+from playwright.async_api import Error as PwError, Page, async_playwright
 
 from vnc.locator_utils import SmartLocator  # 同ディレクトリ
 
@@ -37,19 +38,32 @@ _WATCHER_SCRIPT = None
 # -------------------------------------------------- DSL スキーマ
 _ACTIONS = [
     "navigate",
+    "go_to_url",
+    "search_google",
     "click",
     "click_text",
+    "click_element_by_index",
     "type",
+    "input_text",
     "wait",
     "scroll",
+    "scroll_to_text",
     "go_back",
     "go_forward",
     "hover",
     "select_option",
+    "select_dropdown_option",
     "press_key",
+    "send_keys",
     "wait_for_selector",
     "extract_text",
+    "extract_structured_data",
     "eval_js",
+    "switch_tab",
+    "close_tab",
+    "upload_file_to_element",
+    "get_dropdown_options",
+    "done",
 ]
 payload_schema = {
     "type": "object",
@@ -62,12 +76,23 @@ payload_schema = {
                     "action": {"type": "string", "enum": _ACTIONS},
                     "target": {"type": "string"},
                     "value": {"type": "string"},
+                    "text": {"type": "string"},
+                    "query": {"type": "string"},
+                    "path": {"type": "string"},
                     "ms": {"type": "integer", "minimum": 0},
                     "amount": {"type": "integer"},
                     "direction": {"type": "string", "enum": ["up", "down"]},
                     "key": {"type": "string"},
+                    "keys": {"type": "string"},
                     "retry": {"type": "integer", "minimum": 1},
                     "attr": {"type": "string"},
+                    "index": {"type": "integer", "minimum": 0},
+                    "tab_id": {"type": "string"},
+                    "down": {"type": "boolean"},
+                    "num_pages": {"type": "number"},
+                    "frame_element_index": {"type": "integer", "minimum": 0},
+                    "while_holding_ctrl": {"type": "boolean"},
+                    "new_tab": {"type": "boolean"},
                 },
                 "required": ["action"],
                 "additionalProperties": True,  # ★ 不明キーは許可
@@ -91,14 +116,521 @@ def _validate(data: Dict) -> None:
 LOOP = asyncio.new_event_loop()
 asyncio.set_event_loop(LOOP)
 
-PW = BROWSER = PAGE = None
+PW = None
+BROWSER = None
+CONTEXT = None
+CURRENT_PAGE: Optional[Page] = None
+CURRENT_TAB_ID: Optional[str] = None
+TAB_REGISTRY: Dict[str, Page] = {}
+_TAB_COUNTER = 0
+
+SELECTOR_CACHE: Dict[int, Dict[str, object]] = {}
 EXTRACTED_TEXTS: List[str] = []
 EVAL_RESULTS: List[str] = []
 WARNINGS: List[str] = []
+LAST_SUMMARY: Dict[str, object] | None = None
 
 
 def _run(coro):
     return LOOP.run_until_complete(coro)
+
+
+def _assign_tab_id(page: Page) -> str:
+    global _TAB_COUNTER, TAB_REGISTRY
+    tab_id = getattr(page, "_tab_id", None)
+    if not tab_id:
+        _TAB_COUNTER += 1
+        tab_id = f"{_TAB_COUNTER:04d}"
+        setattr(page, "_tab_id", tab_id)
+    TAB_REGISTRY[tab_id] = page
+    return tab_id
+
+
+def _set_current_page(page: Page) -> None:
+    global CURRENT_PAGE, CURRENT_TAB_ID
+    CURRENT_PAGE = page
+    CURRENT_TAB_ID = _assign_tab_id(page)
+    _sync_open_tabs()
+
+
+def _get_current_page() -> Page:
+    if CURRENT_PAGE is None:
+        raise RuntimeError("browser not initialized")
+    return CURRENT_PAGE
+
+
+def _css_escape(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace('"', '\\"')
+    )
+
+
+def _uniq(seq):
+    seen = set()
+    out = []
+    for item in seq:
+        if item and item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+async def _locator_for_index(index: int, page: Page):
+    info = SELECTOR_CACHE.get(index)
+    if not info:
+        return None
+    selectors = info.get("selectors") or []
+    for sel in selectors:
+        try:
+            loc = await SmartLocator(page, sel).locate()
+            if loc:
+                return loc
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log.debug("locator candidate %s failed: %s", sel, exc)
+    return None
+
+
+async def _page_for_navigation(new_tab: bool | None = None) -> Page:
+    if new_tab and CONTEXT is not None:
+        new_page = await CONTEXT.new_page()
+        _set_current_page(new_page)
+        await new_page.bring_to_front()
+        return new_page
+    page = _get_current_page()
+    await page.bring_to_front()
+    return page
+
+
+def _sync_open_tabs() -> None:
+    if CONTEXT is None:
+        return
+    for page in CONTEXT.pages:
+        if page.is_closed():
+            continue
+        _assign_tab_id(page)
+    to_remove = [tid for tid, pg in TAB_REGISTRY.items() if pg.is_closed()]
+    for tid in to_remove:
+        TAB_REGISTRY.pop(tid, None)
+
+
+JS_SCROLL_TO_TEXT = """
+(text) => {
+    if (!text) {
+        return false;
+    }
+    const needle = String(text).trim().toLowerCase();
+    if (!needle) {
+        return false;
+    }
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+    while (walker.nextNode()) {
+        const el = walker.currentNode;
+        if (!(el instanceof HTMLElement)) {
+            continue;
+        }
+        const style = window.getComputedStyle(el);
+        if (style.visibility === 'hidden' || style.display === 'none') {
+            continue;
+        }
+        const textContent = (el.innerText || '').trim();
+        if (!textContent) {
+            continue;
+        }
+        if (textContent.toLowerCase().includes(needle)) {
+            el.scrollIntoView({behavior: 'instant', block: 'center'});
+            return true;
+        }
+    }
+    return false;
+}
+"""
+
+
+JS_GET_OPTIONS = """
+(el) => {
+    if (!el) {
+        return [];
+    }
+    const options = [];
+    const candidates = el.tagName === 'SELECT'
+        ? Array.from(el.options || [])
+        : Array.from(el.querySelectorAll('option'));
+    for (const opt of candidates) {
+        options.push({
+            text: (opt.textContent || '').trim(),
+            value: opt.value || '',
+            selected: Boolean(opt.selected),
+        });
+    }
+    return options;
+}
+"""
+
+
+JS_COLLECT_ELEMENTS = """
+() => {
+    const interactiveTags = new Set(['a', 'button', 'summary', 'textarea', 'select', 'label', 'details', 'svg', 'div', 'span', 'input']);
+    const interactiveRoles = new Set([
+        'button',
+        'link',
+        'checkbox',
+        'radio',
+        'menuitem',
+        'menuitemcheckbox',
+        'menuitemradio',
+        'tab',
+        'switch',
+        'textbox',
+        'combobox',
+        'listbox',
+        'option',
+        'spinbutton',
+        'slider',
+        'scrollbar',
+        'treeitem',
+    ]);
+    const importantAttrs = [
+        'id',
+        'name',
+        'type',
+        'value',
+        'placeholder',
+        'aria-label',
+        'aria-labelledby',
+        'aria-describedby',
+        'aria-controls',
+        'aria-expanded',
+        'aria-selected',
+        'aria-checked',
+        'aria-haspopup',
+        'role',
+        'href',
+        'title',
+        'tabindex',
+        'data-testid',
+        'data-test',
+        'data-cy',
+        'data-qa',
+        'data-automation-id',
+        'autocomplete',
+        'accept',
+        'pattern',
+        'min',
+        'max',
+        'step',
+    ];
+
+    function isVisible(el) {
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+            return false;
+        }
+        if (el.closest('[aria-hidden="true"]')) {
+            return false;
+        }
+        const rect = el.getBoundingClientRect();
+        if (rect.width < 1 && rect.height < 1) {
+            return false;
+        }
+        return true;
+    }
+
+    function isInteractive(el) {
+        const tag = el.tagName.toLowerCase();
+        if (tag === 'input') {
+            const inputType = (el.getAttribute('type') || 'text').toLowerCase();
+            if (inputType === 'hidden') {
+                return false;
+            }
+            return !el.disabled;
+        }
+        if (interactiveTags.has(tag)) {
+            if (tag === 'a') {
+                return Boolean(el.getAttribute('href')) || interactiveRoles.has((el.getAttribute('role') || '').toLowerCase());
+            }
+            return true;
+        }
+        const role = (el.getAttribute('role') || '').toLowerCase();
+        if (interactiveRoles.has(role)) {
+            return true;
+        }
+        if (el.hasAttribute('onclick') || el.tabIndex >= 0 || el.isContentEditable) {
+            return true;
+        }
+        return false;
+    }
+
+    function describe(el) {
+        if (!el) return '';
+        const tag = el.tagName.toLowerCase();
+        let desc = tag;
+        const id = el.getAttribute('id');
+        if (id) {
+            desc += `#${id}`;
+        }
+        const className = (el.getAttribute('class') || '').trim();
+        if (className) {
+            desc += '.' + className.split(/\s+/).slice(0, 2).join('.');
+        }
+        return desc;
+    }
+
+    function computeXPath(el) {
+        if (!el) return '';
+        const parts = [];
+        let current = el;
+        while (current && current.nodeType === Node.ELEMENT_NODE && current !== document) {
+            const tagName = current.tagName.toLowerCase();
+            let index = 1;
+            let sibling = current.previousElementSibling;
+            while (sibling) {
+                if (sibling.tagName.toLowerCase() === tagName) {
+                    index += 1;
+                }
+                sibling = sibling.previousElementSibling;
+            }
+            parts.unshift(`${tagName}[${index}]`);
+            current = current.parentElement;
+        }
+        return '/' + parts.join('/');
+    }
+
+    const results = [];
+    const root = document.body || document.documentElement;
+    if (!root) {
+        return {title: document.title || '', url: location.href, elements: []};
+    }
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+    let index = 1;
+    while (walker.nextNode()) {
+        const el = walker.currentNode;
+        if (!(el instanceof HTMLElement)) {
+            continue;
+        }
+        if (!isVisible(el)) {
+            continue;
+        }
+        const interactive = isInteractive(el);
+        const scrollable = el.scrollHeight > el.clientHeight + 4;
+        if (!interactive && !scrollable) {
+            continue;
+        }
+
+        const rect = el.getBoundingClientRect();
+        const attrs = {};
+        for (const name of importantAttrs) {
+            const value = el.getAttribute(name);
+            if (value) {
+                attrs[name] = value;
+            }
+        }
+        if (el.dataset && Object.keys(el.dataset).length) {
+            attrs['data'] = {...el.dataset};
+        }
+        if (el.type && !attrs['type']) {
+            attrs['type'] = el.type;
+        }
+
+        const rawText = (() => {
+            if (el.tagName.toLowerCase() === 'input') {
+                return el.value || '';
+            }
+            if (el.tagName.toLowerCase() === 'textarea') {
+                return el.value || el.innerText || '';
+            }
+            return el.innerText || el.textContent || '';
+        })();
+        const text = rawText.replace(/\s+/g, ' ').trim();
+
+        const ancestors = [];
+        let parent = el.parentElement;
+        while (parent && ancestors.length < 4) {
+            ancestors.push(describe(parent));
+            parent = parent.parentElement;
+        }
+
+        results.push({
+            index: index,
+            tag: el.tagName.toLowerCase(),
+            role: (el.getAttribute('role') || '').toLowerCase(),
+            text,
+            attributes: attrs,
+            rect: {
+                x: Math.round(rect.x),
+                y: Math.round(rect.y),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+            },
+            ancestors,
+            isInteractive: interactive,
+            isScrollable: scrollable,
+            xpath: computeXPath(el),
+        });
+        index += 1;
+        if (results.length >= 180) {
+            break;
+        }
+    }
+
+    return {
+        title: document.title || '',
+        url: location.href,
+        elements: results,
+    };
+}
+"""
+
+
+def _compute_selectors(element: Dict[str, object]) -> List[str]:
+    attrs = element.get("attributes") or {}
+    if not isinstance(attrs, dict):
+        attrs = {}
+    selectors: List[str] = []
+    tag = (element.get("tag") or "*").strip() or "*"
+    text = (element.get("text") or "").strip()
+    role = (attrs.get("role") or element.get("role") or "").strip()
+
+    data_block = attrs.get("data") if isinstance(attrs.get("data"), dict) else {}
+    if isinstance(data_block, dict):
+        for key, value in data_block.items():
+            if value:
+                selectors.append(f"css=[data-{key}='{_css_escape(str(value))}']")
+
+    for data_attr in ("data-testid", "data-test", "data-cy", "data-qa", "data-automation-id"):
+        value = attrs.get(data_attr)
+        if value:
+            selectors.append(f"css=[{data_attr}='{_css_escape(str(value))}']")
+
+    if attrs.get("id"):
+        selectors.append(f"css=#{_css_escape(str(attrs['id']))}")
+
+    if attrs.get("name"):
+        selectors.append(f"css={tag}[name='{_css_escape(str(attrs['name']))}']")
+
+    if attrs.get("aria-label"):
+        aria = str(attrs["aria-label"]).strip()
+        selectors.append(f"css=[aria-label='{_css_escape(aria)}']")
+        if role:
+            selectors.append(f"role={role}[name='{_css_escape(aria)}']")
+
+    if attrs.get("title"):
+        selectors.append(f"css={tag}[title='{_css_escape(str(attrs['title']))}']")
+
+    if attrs.get("placeholder"):
+        selectors.append(f"css={tag}[placeholder='{_css_escape(str(attrs['placeholder']))}']")
+
+    if attrs.get("value") and tag in {"button", "input", "option"}:
+        selectors.append(f"css={tag}[value='{_css_escape(str(attrs['value']))}']")
+
+    if attrs.get("href"):
+        selectors.append(f"css={tag}[href='{_css_escape(str(attrs['href']))}']")
+
+    if text:
+        trimmed_text = text[:120]
+        selectors.append(f"text={_css_escape(trimmed_text)}")
+        if role:
+            selectors.append(f"role={role}[name='{_css_escape(trimmed_text)}']")
+
+    if element.get("xpath"):
+        selectors.append(f"xpath={element['xpath']}")
+
+    selectors.append(f"css={tag}")
+    return _uniq(selectors)
+
+
+def _format_summary_line(element: Dict[str, object], selectors: List[str]) -> str:
+    idx = int(element.get("index", 0))
+    tag = element.get("tag", "")
+    text = (element.get("text") or "").strip()
+    attrs = element.get("attributes") or {}
+    if not isinstance(attrs, dict):
+        attrs = {}
+    attr_keys = [
+        "id",
+        "name",
+        "role",
+        "type",
+        "value",
+        "placeholder",
+        "aria-label",
+        "href",
+        "title",
+    ]
+    attr_parts = []
+    for key in attr_keys:
+        value = attrs.get(key)
+        if value:
+            attr_parts.append(f"{key}={value}")
+    data_block = attrs.get("data") if isinstance(attrs.get("data"), dict) else {}
+    if isinstance(data_block, dict):
+        for key, value in data_block.items():
+            if value and len(attr_parts) < 8:
+                attr_parts.append(f"data-{key}={value}")
+
+    rect = element.get("rect") or {}
+    try:
+        pos = f"({int(rect.get('x', 0))},{int(rect.get('y', 0))}) {int(rect.get('width', 0))}x{int(rect.get('height', 0))}"
+    except Exception:
+        pos = "(0,0)"
+
+    ancestors = element.get("ancestors") or []
+    if not isinstance(ancestors, list):
+        ancestors = []
+    parent_text = " > ".join(ancestors[:3])
+
+    label = text[:80]
+    if len(text) > 80:
+        label += "…"
+
+    line = f"[{idx:03d}] <{tag}>{' ' + label if label else ''}"
+    if attr_parts:
+        line += " | " + ", ".join(attr_parts[:8])
+    if element.get("isScrollable"):
+        line += " | scrollable"
+    if parent_text:
+        line += f" | parents: {parent_text}"
+    line += f" | {pos}"
+    if selectors:
+        line += f" | selector hint: {selectors[0]}"
+    return line
+
+
+async def _build_dom_snapshot(limit: int = 140) -> Dict[str, object]:
+    page = _get_current_page()
+    raw = await page.evaluate(JS_COLLECT_ELEMENTS)
+    elements = raw.get("elements") or []
+    if not isinstance(elements, list):
+        elements = []
+    elements.sort(key=lambda e: ((e.get("rect") or {}).get("y", 0), (e.get("rect") or {}).get("x", 0)))
+    trimmed = elements[:limit]
+
+    selector_map: Dict[int, Dict[str, object]] = {}
+    lines: List[str] = []
+    for el in trimmed:
+        try:
+            idx = int(el.get("index", 0))
+        except Exception:
+            continue
+        selectors = _compute_selectors(el)
+        selector_map[idx] = {"selectors": selectors, "text": el.get("text")}
+        lines.append(_format_summary_line(el, selectors))
+
+    SELECTOR_CACHE.clear()
+    SELECTOR_CACHE.update(selector_map)
+
+    summary = {
+        "title": raw.get("title") or "",
+        "url": raw.get("url") or "",
+        "elements": trimmed,
+        "summary": lines,
+    }
+
+    global LAST_SUMMARY
+    LAST_SUMMARY = summary
+    return summary
 
 
 async def _wait_cdp(t: int = 15) -> bool:
@@ -114,25 +646,29 @@ async def _wait_cdp(t: int = 15) -> bool:
 
 
 async def _init_browser():
-    global PW, BROWSER, PAGE
-    if PAGE:
+    global PW, BROWSER, CONTEXT
+    if CURRENT_PAGE:
         return
     PW = await async_playwright().start()
 
+    page: Page | None = None
     if await _wait_cdp():
         try:
             BROWSER = await PW.chromium.connect_over_cdp(CDP_URL)
-            ctx = (
+            CONTEXT = (
                 BROWSER.contexts[0] if BROWSER.contexts else await BROWSER.new_context()
             )
-            PAGE = ctx.pages[0] if ctx.pages else await ctx.new_page()
-            await PAGE.bring_to_front()
+            page = CONTEXT.pages[0] if CONTEXT.pages else await CONTEXT.new_page()
         except PwError:
-            pass
+            log.warning("connect_over_cdp failed, falling back to launch")
 
-    if PAGE is None:
+    if page is None:
         BROWSER = await PW.chromium.launch(headless=True)
-        PAGE = await BROWSER.new_page()
+        CONTEXT = await BROWSER.new_context()
+        page = await CONTEXT.new_page()
+
+    _set_current_page(page)
+    await page.bring_to_front()
 
     # Inject event listener tracking script on every navigation
     global _WATCHER_SCRIPT
@@ -141,11 +677,12 @@ async def _init_browser():
         with open(path, encoding="utf-8") as f:
             _WATCHER_SCRIPT = f.read()
     try:
-        await PAGE.add_init_script(_WATCHER_SCRIPT)
+        await page.add_init_script(_WATCHER_SCRIPT)
     except Exception as e:
         log.error("add_init_script failed: %s", e)
 
-    await PAGE.goto(DEFAULT_URL, wait_until="load")
+    if page.url in ("about:blank", "") or page.url == "chrome://newtab/":
+        await page.goto(DEFAULT_URL, wait_until="load")
     log.info("browser ready")
 
 
@@ -199,7 +736,8 @@ async def _safe_press(l, key: str):
 async def _list_elements(limit: int = 50) -> List[Dict]:
     """Return list of clickable/input elements with basic info."""
     els = []
-    loc = PAGE.locator("a,button,input,textarea,select")
+    page = _get_current_page()
+    loc = page.locator("a,button,input,textarea,select")
     count = await loc.count()
     for i in range(min(count, limit)):
         el = loc.nth(i)
@@ -263,9 +801,10 @@ async def _wait_dom_idle(timeout_ms: int = SPA_STABILIZE_TIMEOUT):
         })
     """
     try:
-        await PAGE.evaluate(script, timeout_ms)
+        page = _get_current_page()
+        await page.evaluate(script, timeout_ms)
     except Exception:
-        await PAGE.wait_for_timeout(100)
+        await _get_current_page().wait_for_timeout(100)
 
 
 # SPA 安定化関数 ----------------------------------------
@@ -273,15 +812,15 @@ async def _stabilize_page():
     """SPA で DOM が書き換わるまで待機する共通ヘルパ."""
     try:
         # ネットワーク要求が終わるまで待機
-        await PAGE.wait_for_load_state("networkidle", timeout=SPA_STABILIZE_TIMEOUT)
+        await _get_current_page().wait_for_load_state("networkidle", timeout=SPA_STABILIZE_TIMEOUT)
     except Exception:
         pass
     await _wait_dom_idle(SPA_STABILIZE_TIMEOUT)
 
 
 async def _apply(act: Dict):
-    global PAGE
-    a = act["action"]
+    page = _get_current_page()
+    action = (act.get("action") or "").lower()
     tgt = act.get("target", "")
     if isinstance(tgt, list):
         tgt = " || ".join(str(s).strip() for s in tgt if s)
@@ -290,46 +829,225 @@ async def _apply(act: Dict):
     amt = int(act.get("amount", 400))
     dir_ = act.get("direction", "down")
 
-    # -- navigate / wait / scroll はロケータ不要
-    if a == "navigate":
-        await PAGE.goto(tgt, wait_until="load", timeout=ACTION_TIMEOUT)
+    if action in {"navigate", "go_to_url"}:
+        url = tgt or val or act.get("url")
+        if not url:
+            raise ValueError("navigate/go_to_url requires a target URL")
+        dest = await _page_for_navigation(bool(act.get("new_tab")))
+        await dest.goto(url, wait_until="load", timeout=ACTION_TIMEOUT)
+        _set_current_page(dest)
         return
-    if a == "go_back":
-        await PAGE.go_back(wait_until="load")
+
+    if action == "search_google":
+        query = act.get("query") or tgt or val
+        if not query:
+            raise ValueError("search_google requires query")
+        url = f"https://www.google.com/search?q={query}&udm=14"
+        dest = await _page_for_navigation(bool(act.get("new_tab")))
+        await dest.goto(url, wait_until="load", timeout=ACTION_TIMEOUT)
+        _set_current_page(dest)
         return
-    if a == "go_forward":
-        await PAGE.go_forward(wait_until="load")
+
+    if action == "go_back":
+        await page.go_back(wait_until="load")
         return
-    if a == "wait":
-        await PAGE.wait_for_timeout(ms)
+
+    if action == "go_forward":
+        await page.go_forward(wait_until="load")
         return
-    if a == "wait_for_selector":
-        await PAGE.wait_for_selector(tgt, state="visible", timeout=ms)
+
+    if action == "wait":
+        await page.wait_for_timeout(ms)
         return
-    if a == "scroll":
-        offset = amt if dir_ == "down" else -amt
+
+    if action == "wait_for_selector":
+        await page.wait_for_selector(tgt, state="visible", timeout=ms)
+        return
+
+    if action == "scroll":
+        down_flag = act.get("down")
+        if down_flag is None:
+            down_flag = dir_.lower() != "up"
+        amount = amt
+        if act.get("num_pages") is not None:
+            viewport = await page.evaluate("() => window.innerHeight || 800")
+            amount = int(float(act.get("num_pages", 1)) * float(viewport))
+        offset = amount if down_flag else -amount
+        frame_idx = act.get("frame_element_index")
+        if frame_idx:
+            loc = await _locator_for_index(int(frame_idx), page)
+            if loc:
+                try:
+                    await loc.first.evaluate("(el, delta) => { el.scrollBy(0, delta); return true; }", offset)
+                    return
+                except Exception as exc:
+                    log.warning("scroll element by index failed: %s", exc)
         if tgt:
-            await PAGE.locator(tgt).evaluate("(el,y)=>el.scrollBy(0,y)", offset)
+            try:
+                await page.locator(tgt).evaluate("(el, delta) => { el.scrollBy(0, delta); return true; }", offset)
+            except Exception:
+                await page.evaluate("(delta) => window.scrollBy(0, delta)", offset)
         else:
-            await PAGE.evaluate("(y)=>window.scrollBy(0,y)", offset)
+            await page.evaluate("(delta) => window.scrollBy(0, delta)", offset)
         return
-    if a == "eval_js":
+
+    if action == "scroll_to_text":
+        text = act.get("text") or tgt or val
+        if text:
+            found = await page.evaluate(JS_SCROLL_TO_TEXT, text)
+            if not found:
+                WARNINGS.append(f"WARNING:auto:scroll_to_text not found: {text}")
+        return
+
+    if action == "switch_tab":
+        tab_id = act.get("tab_id") or (tgt if tgt else None)
+        if not tab_id:
+            return
+        _sync_open_tabs()
+        tab = TAB_REGISTRY.get(tab_id)
+        if tab and not tab.is_closed():
+            _set_current_page(tab)
+            await tab.bring_to_front()
+        else:
+            WARNINGS.append(f"WARNING:auto:tab not found: {tab_id}")
+        return
+
+    if action == "close_tab":
+        tab_id = act.get("tab_id") or CURRENT_TAB_ID
+        if not tab_id:
+            return
+        tab = TAB_REGISTRY.pop(tab_id, None)
+        if tab and not tab.is_closed():
+            await tab.close()
+        if CURRENT_TAB_ID == tab_id:
+            remaining = [pg for pg in TAB_REGISTRY.values() if not pg.is_closed()]
+            if remaining:
+                _set_current_page(remaining[-1])
+                await _get_current_page().bring_to_front()
+            elif CONTEXT is not None:
+                new_page = await CONTEXT.new_page()
+                _set_current_page(new_page)
+                await new_page.bring_to_front()
+        _sync_open_tabs()
+        return
+
+    if action == "send_keys":
+        keys = act.get("keys") or act.get("key")
+        if keys:
+            if "+" in keys:
+                await page.keyboard.press(keys)
+            elif len(keys) == 1:
+                await page.keyboard.type(keys)
+            else:
+                await page.keyboard.type(keys)
+        return
+
+    if action in {"click_element_by_index", "click_element"}:
+        idx = int(act.get("index", 0))
+        loc = await _locator_for_index(idx, page)
+        if not loc:
+            raise ValueError(f"no locator for index {idx}")
+        if act.get("while_holding_ctrl"):
+            await page.keyboard.down("Control")
+            try:
+                await _safe_click(loc)
+            finally:
+                await page.keyboard.up("Control")
+        else:
+            await _safe_click(loc)
+        _sync_open_tabs()
+        return
+
+    if action == "input_text":
+        idx = int(act.get("index", 0))
+        text = act.get("text") if act.get("text") is not None else val
+        clear_existing = act.get("clear_existing", True)
+        if idx == 0:
+            if clear_existing:
+                await page.keyboard.press("Control+A")
+                await page.keyboard.press("Delete")
+            await page.keyboard.type(text)
+        else:
+            loc = await _locator_for_index(idx, page)
+            if not loc:
+                raise ValueError(f"no locator for index {idx}")
+            if clear_existing:
+                await _safe_fill(loc, text)
+            else:
+                await _prepare_element(loc)
+                await loc.first.type(text, timeout=ACTION_TIMEOUT)
+        return
+
+    if action == "upload_file_to_element":
+        idx = int(act.get("index", 0))
+        loc = await _locator_for_index(idx, page)
+        if not loc:
+            raise ValueError(f"no locator for index {idx}")
+        await _prepare_element(loc)
+        paths = act.get("path") or val
+        files = paths if isinstance(paths, list) else [paths]
+        await loc.first.set_input_files(files)
+        return
+
+    if action == "get_dropdown_options":
+        idx = int(act.get("index", 0))
+        loc = await _locator_for_index(idx, page)
+        if not loc:
+            raise ValueError(f"no locator for index {idx}")
+        options = await loc.first.evaluate(JS_GET_OPTIONS)
+        EXTRACTED_TEXTS.append(json.dumps(options, ensure_ascii=False))
+        return
+
+    if action == "select_dropdown_option":
+        idx = int(act.get("index", 0))
+        choice = act.get("text") or act.get("value") or val
+        loc = await _locator_for_index(idx, page)
+        if not loc:
+            raise ValueError(f"no locator for index {idx}")
+        await _prepare_element(loc)
+        try:
+            await loc.first.select_option(label=choice)
+        except Exception:
+            await loc.first.select_option(value=choice)
+        return
+
+    if action == "extract_structured_data":
+        if act.get("index"):
+            loc = await _locator_for_index(int(act["index"]), page)
+            if loc:
+                text = await loc.first.inner_text()
+                EXTRACTED_TEXTS.append(text)
+                return
+        if tgt:
+            loc = await SmartLocator(page, tgt).locate()
+            if loc:
+                text = await loc.first.inner_text()
+                EXTRACTED_TEXTS.append(text)
+                return
+        body_text = await page.inner_text("body")
+        EXTRACTED_TEXTS.append(body_text)
+        return
+
+    if action == "done":
+        return
+
+    if action == "eval_js":
         script = act.get("script") or val
         if script:
             try:
-                result = await PAGE.evaluate(script)
+                result = await page.evaluate(script)
                 EVAL_RESULTS.append(result)
             except Exception as e:
                 log.error("eval_js error: %s", e)
         return
 
-    # -- ロケータ系
+    # Fallback to legacy locator-based actions
     loc: Optional = None
     for _ in range(LOCATOR_RETRIES):
-        if a == "click_text":
-            loc = await SmartLocator(PAGE, f"text={tgt}").locate()
+        if action == "click_text":
+            loc = await SmartLocator(page, f"text={tgt}").locate()
         else:
-            loc = await SmartLocator(PAGE, tgt).locate()
+            loc = await SmartLocator(page, tgt).locate()
         if loc is not None:
             break
         await _stabilize_page()
@@ -340,19 +1058,19 @@ async def _apply(act: Dict):
         WARNINGS.append(f"WARNING:auto:{msg}")
         return
 
-    if a in ("click", "click_text"):
+    if action in ("click", "click_text"):
         await _safe_click(loc)
-    elif a == "type":
+    elif action in ("type",):
         await _safe_fill(loc, val)
-    elif a == "hover":
+    elif action == "hover":
         await _safe_hover(loc)
-    elif a == "select_option":
+    elif action == "select_option":
         await _safe_select(loc, val)
-    elif a == "press_key":
+    elif action == "press_key":
         key = act.get("key", "")
         if key:
             await _safe_press(loc, key)
-    elif a == "extract_text":
+    elif action == "extract_text":
         attr = act.get("attr")
         if attr:
             text = await loc.get_attribute(attr)
@@ -377,7 +1095,8 @@ async def _run_actions(actions: List[Dict]) -> tuple[str, List[str]]:
                 log.error("action error (%d/%d): %s", attempt, retries, e)
                 if attempt == retries:
                     raise
-    return await PAGE.content(), WARNINGS.copy()
+    page = _get_current_page()
+    return await page.content(), WARNINGS.copy()
 
 
 # -------------------------------------------------- HTTP エンドポイント
@@ -403,11 +1122,25 @@ def execute_dsl():
         return jsonify(error="ExecutionError", message=str(e)), 500
 
 
+@app.get("/dom")
+def dom_summary():
+    try:
+        _run(_init_browser())
+        snapshot = _run(_build_dom_snapshot())
+        return jsonify(snapshot)
+    except Exception as e:
+        log.error("dom_summary error: %s", e)
+        if LAST_SUMMARY:
+            return jsonify({**LAST_SUMMARY, "error": str(e)}), 200
+        return jsonify(error=str(e)), 500
+
+
 @app.get("/source")
 def source():
     try:
         _run(_init_browser())
-        return Response(_run(PAGE.content()), mimetype="text/plain")
+        page = _get_current_page()
+        return Response(_run(page.content()), mimetype="text/plain")
     except Exception as e:
         return jsonify(error=str(e)), 500
 
@@ -416,7 +1149,8 @@ def source():
 def screenshot():
     try:
         _run(_init_browser())
-        img = _run(PAGE.screenshot(type="png"))
+        page = _get_current_page()
+        img = _run(page.screenshot(type="png"))
         return Response(base64.b64encode(img), mimetype="text/plain")
     except Exception as e:
         return jsonify(error=str(e)), 500


### PR DESCRIPTION
## Summary
- replace legacy DOM element parsing with a compact DOMSnapshot summary used across the agent
- extend the automation server and helper utilities with browser-use style actions (index-based clicks, tab controls, dropdown helpers, etc.)
- refresh the controller prompt and web app pipeline to consume the new snapshot and instruct the LLM on the broader action set

## Testing
- python -m compileall agent web

------
https://chatgpt.com/codex/tasks/task_e_68cf70e7da848320ab57e016af76bf6a