### PR TITLE
Refactor automation pipeline to use browser-use

### DIFF
--- a/agent/browser_use_runner.py
+++ b/agent/browser_use_runner.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from browser_use.agent.service import Agent, AgentHistoryList
+from browser_use.browser.views import BrowserStateSummary
+from browser_use.agent.views import AgentOutput
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.groq.chat import ChatGroq
+
+from agent.utils.history import append_history_entry
+
+log = logging.getLogger(__name__)
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _normalise_screenshot(data: Optional[str]) -> Optional[str]:
+    if not data:
+        return None
+    if data.startswith("data:image"):
+        return data
+    return f"data:image/png;base64,{data}"
+
+
+@dataclass
+class BrowserUseSession:
+    command: str
+    model_name: str
+    max_steps: int
+    session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    status: str = "pending"
+    error: Optional[str] = None
+    steps: list[Dict[str, Any]] = field(default_factory=list)
+    result: Optional[Dict[str, Any]] = None
+    created_at: float = field(default_factory=_now)
+    updated_at: float = field(default_factory=_now)
+
+    _task: asyncio.Task | None = field(default=None, init=False, repr=False)
+    _agent: Agent | None = field(default=None, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _history_recorded: bool = field(default=False, init=False, repr=False)
+
+    async def run(self) -> None:
+        self._task = asyncio.current_task()
+        try:
+            llm = self._create_llm()
+        except Exception as exc:  # pragma: no cover - configuration error path
+            log.error("Failed to create LLM for session %s: %s", self.session_id, exc)
+            self._set_status("failed", str(exc))
+            self._record_history()
+            return
+
+        try:
+            self._set_status("running")
+            self._agent = Agent(
+                task=self.command,
+                llm=llm,
+                register_new_step_callback=self._on_step,
+                generate_gif=False,
+                use_vision=True,
+                max_actions_per_step=10,
+            )
+            history: AgentHistoryList = await self._agent.run(max_steps=self.max_steps)
+            self._finalise_result(history)
+            self._set_status("completed")
+        except asyncio.CancelledError:
+            self._set_status("cancelled")
+            raise
+        except Exception as exc:  # pragma: no cover - runtime failure path
+            log.exception("Browser-use session %s failed", self.session_id)
+            self._set_status("failed", str(exc))
+        finally:
+            try:
+                if self._agent is not None:
+                    await self._agent.close()
+            except Exception as close_exc:  # pragma: no cover - defensive
+                log.debug("Error closing agent for session %s: %s", self.session_id, close_exc)
+            self._record_history()
+
+    async def request_cancel(self) -> None:
+        task = self._task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def _on_step(
+        self,
+        browser_state: BrowserStateSummary,
+        model_output: AgentOutput,
+        step_number: int,
+    ) -> None:
+        dom_excerpt = ""
+        try:
+            dom_text = browser_state.dom_state.llm_representation()
+            if len(dom_text) > 2000:
+                dom_excerpt = dom_text[:2000] + "\n…"
+            else:
+                dom_excerpt = dom_text
+        except Exception as exc:  # pragma: no cover - best effort only
+            dom_excerpt = f"DOM extraction failed: {exc}"
+
+        actions = [action.model_dump(exclude_none=True) for action in model_output.action]
+        step_payload: Dict[str, Any] = {
+            "index": step_number,
+            "url": browser_state.url,
+            "title": browser_state.title,
+            "thinking": model_output.thinking,
+            "evaluation": model_output.evaluation_previous_goal,
+            "memory": model_output.memory,
+            "next_goal": model_output.next_goal,
+            "actions": actions,
+            "screenshot": _normalise_screenshot(browser_state.screenshot),
+            "dom_excerpt": dom_excerpt,
+            "timestamp": _now(),
+        }
+        with self._lock:
+            self.steps.append(step_payload)
+            self.updated_at = _now()
+
+    def _finalise_result(self, history: AgentHistoryList) -> None:
+        structured = history.structured_output()
+        result: Dict[str, Any] = {
+            "success": history.is_successful(),
+            "errors": [err for err in history.errors() if err],
+            "final_result": history.final_result(),
+            "urls": [url for url in history.urls() if url],
+            "total_steps": history.number_of_steps(),
+            "duration_seconds": history.total_duration_seconds(),
+        }
+        if structured is not None:
+            try:
+                result["structured_output"] = structured.model_dump()
+            except Exception:  # pragma: no cover - defensive
+                result["structured_output"] = str(structured)
+
+        with self._lock:
+            self.result = result
+            self.updated_at = _now()
+
+    def _create_llm(self) -> BaseChatModel:
+        requested = (self.model_name or "").strip()
+        model_key = requested.lower()
+
+        if not model_key or model_key == "gemini":
+            model_name = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
+            api_key = os.getenv("GEMINI_API_KEY")
+            if not api_key:
+                raise ValueError("GEMINI_API_KEY is not configured")
+            return ChatGoogle(model=model_name, api_key=api_key)
+
+        if model_key == "groq":
+            model_name = os.getenv("GROQ_MODEL", "meta-llama/llama-4-scout-17b-16e-instruct")
+            api_key = os.getenv("GROQ_API_KEY")
+            if not api_key:
+                raise ValueError("GROQ_API_KEY is not configured")
+            return ChatGroq(model=model_name, api_key=api_key)
+
+        if model_key.startswith("gemini"):
+            api_key = os.getenv("GEMINI_API_KEY")
+            if not api_key:
+                raise ValueError("GEMINI_API_KEY is not configured")
+            return ChatGoogle(model=requested, api_key=api_key)
+
+        if any(token in model_key for token in ("/", "llama", "mixtral", "gemma")):
+            api_key = os.getenv("GROQ_API_KEY")
+            if not api_key:
+                raise ValueError("GROQ_API_KEY is not configured")
+            return ChatGroq(model=requested, api_key=api_key)
+
+        # Fallback: try Gemini first, then Groq if Gemini fails
+        gemini_key = os.getenv("GEMINI_API_KEY")
+        if gemini_key:
+            return ChatGoogle(model=requested, api_key=gemini_key)
+        groq_key = os.getenv("GROQ_API_KEY")
+        if groq_key:
+            return ChatGroq(model=requested, api_key=groq_key)
+        raise ValueError(f"Unsupported model '{requested}'")
+
+    def _set_status(self, status: str, error: Optional[str] = None) -> None:
+        with self._lock:
+            self.status = status
+            if error:
+                self.error = error
+            self.updated_at = _now()
+
+    def _record_history(self) -> None:
+        if self._history_recorded:
+            return
+        with self._lock:
+            payload = {
+                "status": self.status,
+                "model": self.model_name,
+                "steps": copy.deepcopy(self.steps),
+                "result": copy.deepcopy(self.result),
+                "error": self.error,
+                "complete": self.status == "completed",
+            }
+            final_url = self._final_url_locked(payload)
+            self._history_recorded = True
+        try:
+            append_history_entry(self.command, payload, final_url)
+        except Exception as exc:  # pragma: no cover - IO failure path
+            log.error("Failed to persist history for session %s: %s", self.session_id, exc)
+
+    def _final_url_locked(self, payload: Dict[str, Any]) -> Optional[str]:
+        steps = payload.get("steps") or []
+        if steps:
+            url = steps[-1].get("url")
+            if url:
+                return url
+        result = payload.get("result") or {}
+        urls = result.get("urls") or []
+        if urls:
+            return urls[-1]
+        return None
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "session_id": self.session_id,
+                "command": self.command,
+                "model": self.model_name,
+                "status": self.status,
+                "error": self.error,
+                "steps": copy.deepcopy(self.steps),
+                "result": copy.deepcopy(self.result),
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+                "complete": self.status == "completed",
+            }
+
+
+class BrowserUseManager:
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+        self._sessions: Dict[str, BrowserUseSession] = {}
+        self._lock = threading.Lock()
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def start_session(self, command: str, *, model: str, max_steps: int) -> str:
+        session = BrowserUseSession(command=command, model_name=model, max_steps=max_steps)
+        with self._lock:
+            self._sessions[session.session_id] = session
+        asyncio.run_coroutine_threadsafe(session.run(), self._loop)
+        log.info("Started browser-use session %s for command: %s", session.session_id, command)
+        return session.session_id
+
+    def get_status(self, session_id: str) -> Optional[Dict[str, Any]]:
+        session = self._sessions.get(session_id)
+        if not session:
+            return None
+        return session.snapshot()
+
+    def cancel_session(self, session_id: str) -> bool:
+        session = self._sessions.get(session_id)
+        if not session:
+            return False
+        future = asyncio.run_coroutine_threadsafe(session.request_cancel(), self._loop)
+        try:
+            future.result(timeout=10)
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            log.error("Failed to cancel session %s: %s", session_id, exc)
+            return False
+
+    def shutdown(self) -> None:
+        with self._lock:
+            sessions = list(self._sessions.values())
+        for session in sessions:
+            future = asyncio.run_coroutine_threadsafe(session.request_cancel(), self._loop)
+            try:
+                future.result(timeout=5)
+            except Exception:  # pragma: no cover - best effort
+                pass
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5)
+
+
+_browser_use_manager: BrowserUseManager | None = None
+
+
+def get_browser_use_manager() -> BrowserUseManager:
+    global _browser_use_manager
+    if _browser_use_manager is None:
+        _browser_use_manager = BrowserUseManager()
+    return _browser_use_manager

--- a/web/app.py
+++ b/web/app.py
@@ -1,697 +1,128 @@
-import os
-import json
+from __future__ import annotations
+
+import atexit
 import logging
-import re
-from typing import Any, Dict
-import requests
-from flask import (
-    Flask,
-    request,
-    jsonify,
-    render_template,
-    Response,
-    send_from_directory,
-)
+import os
+from typing import Any
 
-# --------------- Agent modules -----------------------------------
-from agent.llm.client import call_llm
-from agent.browser.vnc import (
-    get_html as vnc_html,
-    execute_dsl,
-    get_elements as vnc_elements,
-    get_dom_tree as vnc_dom_tree,
-    get_url as vnc_url,
-    get_vnc_api_base,
-)
-from agent.browser.dom import DOMElementNode
-from agent.controller.prompt import build_prompt
-from agent.controller.async_executor import get_async_executor
-from agent.utils.history import load_hist, save_hist, append_history_entry
-from agent.utils.html import strip_html
-from agent.element_catalog import (
-    actions_use_catalog_indices,
-    consume_pending_prompt_messages,
-    get_catalog_for_prompt,
-    get_expected_version as get_catalog_expected_version,
-    is_enabled as is_catalog_enabled,
-    record_prompt_version,
-    should_refresh_for_prompt,
-)
-from vnc.dependency_check import ensure_component_dependencies
+from flask import Flask, jsonify, render_template, request, send_from_directory
 
-# --------------- Flask & Logger ----------------------------------
+from agent.browser_use_runner import get_browser_use_manager
+from agent.utils import history as history_utils
+from agent.utils.history import load_hist, save_hist
+
 app = Flask(__name__)
 log = logging.getLogger("agent")
 log.setLevel(logging.INFO)
 
-# Validate that the Flask service has access to its declared dependencies at
-# startup.  This makes missing packages surface as a clear actionable error.
-ensure_component_dependencies("web", logger=log)
-
-# Pre-initialize AsyncExecutor for immediate Playwright execution
-_async_executor_instance = None
-
-def get_preinitialized_async_executor():
-    """Get pre-initialized async executor to reduce startup overhead."""
-    global _async_executor_instance
-    if _async_executor_instance is None:
-        _async_executor_instance = get_async_executor()
-        log.info("Pre-initialized AsyncExecutor for immediate execution")
-    return _async_executor_instance
-
-
-@app.errorhandler(500)
-def internal_server_error(error):
-    """Global error handler to convert 500 errors to JSON warnings."""
-    import uuid
-    correlation_id = str(uuid.uuid4())[:8]
-    error_msg = f"Internal server error - {str(error)}"
-    log.exception("[%s] Unhandled exception: %s", correlation_id, error_msg)
-    
-    return jsonify({
-        "error": f"Internal failure - An unexpected error occurred",
-        "correlation_id": correlation_id
-    }), 200  # Return 200 instead of 500
+MAX_STEPS = max(1, int(os.getenv("MAX_STEPS", "15")))
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gemini")
+HIST_FILE = history_utils.HIST_FILE
 
 
 @app.errorhandler(404)
-def not_found_error(error):
-    """Handle 404 errors without logging a full exception."""
-    import uuid
-    correlation_id = str(uuid.uuid4())[:8]
-    # Avoid noisy stack traces for missing routes
-    return jsonify({
-        "error": f"Resource not found - {request.path}",
-        "correlation_id": correlation_id
-    }), 200
+def not_found(error: Exception):  # pragma: no cover - simple JSON handler
+    return jsonify({"error": f"resource not found: {request.path}"}), 404
 
 
 @app.errorhandler(Exception)
-def handle_exception(error):
-    """Global exception handler to catch all uncaught exceptions."""
-    import uuid
-    correlation_id = str(uuid.uuid4())[:8]
-    log.exception("[%s] Uncaught exception: %s", correlation_id, str(error))
-    
-    return jsonify({
-        "error": f"Internal failure - {str(error)}",
-        "correlation_id": correlation_id
-    }), 200  # Return 200 instead of 500
-
-# --------------- VNC / Playwright API ----------------------------
-# Default to a blank page to prevent unintended navigation to external sites
-START_URL = os.getenv("START_URL", "about:blank")
-MAX_STEPS = int(os.getenv("MAX_STEPS", "30"))
-
-# --------------- Conversation History ----------------------------
-LOG_DIR = os.getenv("LOG_DIR", "./")
-os.makedirs(LOG_DIR, exist_ok=True)
-HIST_FILE = os.path.join(LOG_DIR, "conversation_history.json")
+def handle_exception(error: Exception):  # pragma: no cover - defensive handler
+    log.exception("Unhandled exception: %s", error)
+    return jsonify({"error": "internal server error"}), 500
 
 
-def _vnc_api_url(path: str) -> str:
-    """Build a URL for the automation server using the resolved base URL."""
+@app.route("/")
+def index():
+    return render_template(
+        "layout.html",
+        default_model=DEFAULT_MODEL,
+        max_steps=MAX_STEPS,
+    )
 
-    base = get_vnc_api_base()
-    if not path.startswith("/"):
-        path = "/" + path
-    return f"{base}{path}"
 
+@app.post("/execute")
+def execute():
+    data: dict[str, Any] = request.get_json(force=True) or {}
+    command = str(data.get("command", "")).strip()
+    if not command:
+        return jsonify({"error": "command empty"}), 400
 
-def _format_index_value(value: Any) -> str | None:
-    """Convert index-like values to the legacy ``index=N`` selector form."""
+    model = str(data.get("model") or DEFAULT_MODEL).strip()
+    requested_steps = data.get("max_steps")
+    max_steps = MAX_STEPS
+    if requested_steps is not None:
+        try:
+            max_steps = int(requested_steps)
+        except (TypeError, ValueError):
+            return jsonify({"error": "max_steps must be an integer"}), 400
+        if max_steps <= 0:
+            return jsonify({"error": "max_steps must be positive"}), 400
 
-    if isinstance(value, bool):
-        return None
-
-    if isinstance(value, int):
-        if value < 0:
-            return None
-        return f"index={value}"
-
-    if isinstance(value, float):
-        if value.is_integer() and value >= 0:
-            return f"index={int(value)}"
-        return None
-
+    manager = get_browser_use_manager()
     try:
-        text = str(value).strip()
-    except Exception:
-        return None
+        session_id = manager.start_session(command, model=model, max_steps=max_steps)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:  # pragma: no cover - runtime failure path
+        log.exception("Failed to start automation run")
+        return jsonify({"error": "failed to start automation"}), 500
 
-    if not text:
-        return None
+    return jsonify({"session_id": session_id})
 
+
+@app.get("/status/<session_id>")
+def get_status(session_id: str):
+    info = get_browser_use_manager().get_status(session_id)
+    if info is None:
+        return jsonify({"error": "session not found"}), 404
+    return jsonify(info)
+
+
+@app.post("/cancel/<session_id>")
+def cancel(session_id: str):
+    manager = get_browser_use_manager()
+    if not manager.cancel_session(session_id):
+        return jsonify({"error": "session not found"}), 404
+    return jsonify({"status": "cancelled"})
+
+
+@app.get("/history")
+def history():
     try:
-        idx = int(text)
-    except ValueError:
-        return None
-
-    if idx < 0:
-        return None
-
-    return f"index={idx}"
+        return jsonify(load_hist())
+    except Exception as exc:  # pragma: no cover - defensive
+        log.error("Failed to load history: %s", exc)
+        return jsonify({"error": "failed to load history", "data": []}), 500
 
 
-def _escape_quotes(value: str) -> str:
-    return value.replace("\"", "\\\"")
-
-
-def _stringify_selector(selector: Any) -> str:
-    """Convert structured selector data into the legacy string-based DSL form."""
-
-    if selector is None:
-        return ""
-
-    if isinstance(selector, str):
-        return selector
-
-    if isinstance(selector, list):
-        parts = []
-        for item in selector:
-            formatted = _stringify_selector(item)
-            if formatted:
-                if formatted not in parts:
-                    parts.append(formatted)
-        return " || ".join(parts)
-
-    index_form = _format_index_value(selector)
-    if index_form:
-        return index_form
-
-    if isinstance(selector, dict):
-        if "selector" in selector and selector["selector"]:
-            candidate = _stringify_selector(selector["selector"])
-            if candidate:
-                return candidate
-
-        if "index" in selector:
-            index_form = _format_index_value(selector.get("index"))
-            if index_form:
-                return index_form
-
-        css_value = selector.get("css")
-        if css_value:
-            return f"css={css_value}"
-
-        xpath_value = selector.get("xpath")
-        if xpath_value:
-            return f"xpath={xpath_value}"
-
-        role_value = selector.get("role")
-        if role_value:
-            name_value = selector.get("name") or selector.get("text")
-            role_value = str(role_value).strip()
-            if name_value:
-                name_text = _escape_quotes(str(name_value).strip())
-                if name_text:
-                    return f'role={role_value}[name="{name_text}"]'
-            if role_value:
-                return f"role={role_value}"
-
-        text_value = selector.get("text")
-        if text_value:
-            return str(text_value)
-
-        aria_label = selector.get("aria_label") or selector.get("aria-label")
-        if aria_label:
-            escaped = _escape_quotes(str(aria_label).strip())
-            if escaped:
-                return f'css=[aria-label="{escaped}"]'
-
-        stable_id = selector.get("stable_id")
-        if stable_id:
-            stable = str(stable_id).strip()
-            if stable:
-                escaped = _escape_quotes(stable)
-                candidates = [f'css=[data-testid="{escaped}"]', f'css=[name="{escaped}"]']
-                if re.fullmatch(r"[A-Za-z_][-A-Za-z0-9_]*", stable):
-                    candidates.insert(1, f"css=#{stable}")
-                return " || ".join(candidates)
-
-        for key in ("value", "target"):
-            if selector.get(key):
-                candidate = _stringify_selector(selector[key])
-                if candidate:
-                    return candidate
-
-        for key, value in selector.items():
-            if isinstance(value, str) and value.strip():
-                return value
-            if isinstance(value, (int, float)) and not isinstance(value, bool):
-                return str(value)
-
-    # Fallback to simple string conversion for any remaining types
-    try:
-        return str(selector)
-    except Exception:
-        return ""
-
-
-def normalize_actions(llm_response):
-    """Extract and normalize actions from LLM response (optimized for speed)."""
-    if not llm_response:
-        return []
-    
-    actions = llm_response.get("actions", [])
-    if not isinstance(actions, list):
-        return []
-    
-    # Optimized normalization using list comprehension for speed
-    normalized = []
-    for action in actions:
-        if not isinstance(action, dict):
-            continue
-            
-        # Create normalized action with proper lowercasing
-        normalized_action = dict(action)  # Start with copy
-        
-        # Normalize action name to lowercase
-        if "action" in normalized_action:
-            normalized_action["action"] = str(normalized_action["action"]).lower()
-        
-        # Handle selector -> target mapping (optimized)
-        if "selector" in action and "target" not in action:
-            normalized_action["target"] = action["selector"]
-            
-        # Handle click_text action (optimized)
-        elif (normalized_action.get("action") == "click_text" and
-              "text" in action and "target" not in action):
-            normalized_action["target"] = action["text"]
-
-        if "target" in normalized_action:
-            normalized_action["target"] = _stringify_selector(normalized_action["target"])
-
-        if "value" in normalized_action and not isinstance(normalized_action["value"], str):
-            normalized_action["value"] = str(normalized_action["value"])
-
-        normalized.append(normalized_action)
-
-    return normalized
-
-
-@app.route("/history", methods=["GET"])
-def get_history():
-    try:
-        history_data = load_hist()
-        return jsonify(history_data)
-    except Exception as e:
-        import uuid
-        correlation_id = str(uuid.uuid4())[:8]
-        log.error("[%s] get_history error: %s", correlation_id, e)
-        # Return structured error response instead of 500
-        return jsonify({
-            "error": f"Failed to load history - {str(e)}",
-            "correlation_id": correlation_id,
-            "data": []  # Provide empty data as fallback
-        }), 200
-
-
-@app.route("/history.json", methods=["GET"])
-def download_history():
+@app.get("/history.json")
+def history_file():
     if os.path.exists(HIST_FILE):
         return send_from_directory(
             directory=os.path.dirname(HIST_FILE),
             path=os.path.basename(HIST_FILE),
             mimetype="application/json",
         )
-    return jsonify(error="history file not found"), 404
+    return jsonify({"error": "history file not found"}), 404
 
 
-# ----- Memory endpoint -----
-@app.route("/memory", methods=["GET"])
-def memory():
-    try:
-        history_data = load_hist()
-        return jsonify(history_data)
-    except Exception as e:
-        import uuid
-        correlation_id = str(uuid.uuid4())[:8]
-        log.error("[%s] memory error: %s", correlation_id, e)
-        # Return structured error response instead of 500
-        return jsonify({
-            "error": f"Failed to load memory - {str(e)}",
-            "correlation_id": correlation_id,
-            "data": []  # Provide empty data as fallback
-        }), 200
-
-
-# ----- Reset endpoint -----
 @app.post("/reset")
 def reset():
-    """Reset conversation history by clearing the history file"""
     try:
-        # Clear the history by saving an empty list
         save_hist([])
-        log.info("Conversation history reset successfully")
         return jsonify({"status": "success", "message": "会話履歴がリセットされました"})
-    except Exception as e:
-        log.error("reset error: %s", e)
-        return jsonify(error=str(e)), 500
+    except Exception as exc:  # pragma: no cover - defensive
+        log.error("Failed to reset history: %s", exc)
+        return jsonify({"error": str(exc)}), 500
 
 
-def update_last_history_url(url=None):
-    """Update the most recent conversation entry with the current page URL."""
+@atexit.register
+def _shutdown_manager() -> None:  # pragma: no cover - shutdown hook
     try:
-        hist = load_hist()
-        if not hist:
-            log.debug("No conversation history found to update with URL")
-            return
-
-        # Use provided URL or fetch from VNC server
-        current_url = url
-        if not current_url:
-            try:
-                current_url = vnc_url()
-            except Exception as vnc_error:
-                log.error("Failed to get URL from VNC server: %s", vnc_error)
-                return
-        
-        if current_url:  # Only update if we have a valid URL
-            hist[-1]["url"] = current_url
-            save_hist(hist)
-            log.debug("Updated conversation history URL to: %s", current_url)
-        else:
-            log.warning("No valid URL available to update conversation history")
-            
-    except Exception as e:
-        log.error("update_last_history_url error: %s", e)
+        get_browser_use_manager().shutdown()
+    except Exception as exc:
+        log.debug("Shutdown cleanup failed: %s", exc)
 
 
-# --------------- API ---------------------------------------------
-@app.post("/execute")
-def execute():
-    data = request.get_json(force=True)
-    cmd = data.get("command", "").strip()
-    if not cmd:
-        return jsonify(error="command empty"), 400
-
-    page = data.get("pageSource") or vnc_html()
-    shot = data.get("screenshot")
-    model = data.get("model", "gemini")
-    prev_error = data.get("error")
-    hist = load_hist()
-    current_url = data.get("url") or vnc_url()
-    elements, dom_err = vnc_dom_tree()
-    if elements is None:
-        try:
-            fallback = vnc_elements()
-            elements = [
-                DOMElementNode(
-                    tagName=e.get("tag", ""),
-                    attributes={
-                        k: v
-                        for k, v in {
-                            "id": e.get("id"),
-                            "class": e.get("class"),
-                        }.items()
-                        if v
-                    },
-                    text=e.get("text"),
-                    xpath=e.get("xpath", ""),
-                    highlightIndex=e.get("index"),
-                    isVisible=True,
-                    isInteractive=True,
-                )
-                for e in fallback
-            ]
-        except Exception as fbe:
-            log.error("fallback elements error: %s", fbe)
-    err_msg = "\n".join(filter(None, [prev_error, dom_err])) or None
-    pending_catalog_messages = consume_pending_prompt_messages() if is_catalog_enabled() else []
-    if pending_catalog_messages:
-        combined = "\n".join(pending_catalog_messages)
-        log.debug("Catalog advisory added to prompt: %s", combined)
-        err_msg = "\n".join(filter(None, [err_msg, combined]))
-
-    catalog_prompt_text = ""
-    catalog_data: Dict[str, Any] = {"abbreviated": [], "metadata": {}, "catalog_version": None}
-    expected_catalog_version = None
-    if is_catalog_enabled():
-        try:
-            refresh_catalog = should_refresh_for_prompt()
-            if refresh_catalog:
-                log.debug("Forcing element catalog refresh before prompting")
-            catalog_info = get_catalog_for_prompt(refresh=refresh_catalog)
-            catalog_prompt_text = catalog_info.get("prompt_text", "")
-            catalog_data = catalog_info.get("catalog", {}) or {}
-            expected_catalog_version = catalog_data.get("catalog_version") or get_catalog_expected_version()
-            record_prompt_version(expected_catalog_version)
-        except Exception as catalog_error:
-            log.error("Failed to fetch element catalog: %s", catalog_error)
-
-    prompt = build_prompt(
-        cmd,
-        page,
-        hist,
-        bool(shot),
-        elements,
-        err_msg,
-        element_catalog_text=catalog_prompt_text,
-        catalog_metadata=catalog_data,
-    )
-    
-    # Call LLM first
-    res = call_llm(prompt, model, shot)
-
-    # Save conversation history immediately with current URL
-    append_history_entry(cmd, res, current_url)
-    
-    # Extract and normalize actions from LLM response
-    actions = normalize_actions(res)
-    uses_catalog_indices = bool(actions) and is_catalog_enabled() and actions_use_catalog_indices(actions)
-    if uses_catalog_indices:
-        log.debug("Planned actions rely on catalog indices")
-
-    # If there are actions, start async Playwright execution immediately (optimized)
-    task_id = None
-    if actions:
-        try:
-            # Use pre-initialized executor for immediate execution
-            executor = get_preinitialized_async_executor()
-            task_id = executor.create_task()
-
-            # Start Playwright execution in parallel (immediate submission)
-            payload_extra = {}
-            if is_catalog_enabled() and expected_catalog_version:
-                payload_extra["expected_catalog_version"] = expected_catalog_version
-            success = executor.submit_playwright_execution(
-                task_id,
-                execute_dsl,
-                actions,
-                payload=payload_extra or None,
-            )
-            
-            if success:
-                # Start parallel data fetching immediately (no delay)
-                executor.submit_parallel_data_fetch(task_id, {"updated_html": vnc_html})
-                log.info("Started immediate async execution for task %s", task_id)
-            else:
-                log.error("Failed to start async execution")
-                task_id = None
-        except Exception as e:
-            log.error("Error starting async execution: %s", e)
-            task_id = None
-    
-    # Return LLM response immediately with task_id for status tracking (optimized)
-    if task_id:
-        # Direct field assignment instead of dict copying for speed
-        res["task_id"] = task_id
-        res["async_execution"] = True
-    else:
-        res["async_execution"] = False
-    
-    return jsonify(res)
-
-
-@app.route("/execution-status/<task_id>", methods=["GET"])
-def get_execution_status(task_id):
-    """Get the status of an async execution task."""
-    try:
-        executor = get_async_executor()
-        status = executor.get_task_status(task_id)
-
-        if status is None:
-            return jsonify({"error": "Task not found"}), 404
-
-        # When task completes, update conversation history with current URL
-        if status.get("status") == "completed":
-            update_last_history_url()
-
-        # Include all warnings without character limits
-        if status and "result" in status and status["result"] and isinstance(status["result"], dict):
-            if "warnings" in status["result"] and status["result"]["warnings"]:
-                status["result"]["warnings"] = [_truncate_warning(warning) for warning in status["result"]["warnings"]]
-        
-        # Clean up old tasks periodically
-        executor.cleanup_old_tasks()
-        
-        return jsonify(status)
-        
-    except Exception as e:
-        import uuid
-        correlation_id = str(uuid.uuid4())[:8]
-        log.error("[%s] get_execution_status error: %s", correlation_id, e)
-        error_warning = _truncate_warning(f"Failed to get status - {str(e)}")
-        return jsonify({
-            "error": error_warning,
-            "correlation_id": correlation_id
-        }), 200
-
-
-@app.post("/store-warnings")
-def store_warnings():
-    """Store warnings in the last conversation history item."""
-    try:
-        data = request.get_json(force=True)
-        warnings = data.get("warnings", [])
-        
-        if not warnings:
-            return jsonify({"status": "success", "message": "No warnings to store"})
-        
-        # Process warnings without character limits (as requested)
-        processed_warnings = [_truncate_warning(warning) for warning in warnings]
-        
-        # Load current history
-        hist = load_hist()
-        
-        if not hist:
-            log.warning("No conversation history found to update with warnings")
-            return jsonify({"status": "error", "message": "No conversation history found"})
-        
-        # Get the last conversation item
-        last_item = hist[-1]
-        
-        # Add warnings to the bot response, above the "complete" field
-        if "bot" in last_item and isinstance(last_item["bot"], dict):
-            # Make a copy of bot response to preserve order
-            bot_response = last_item["bot"].copy()
-            
-            # Remove complete field temporarily
-            complete_value = bot_response.pop("complete", True)
-            
-            # Add processed warnings (without character limits)
-            bot_response["warnings"] = processed_warnings
-            
-            # Re-add complete field at the end
-            bot_response["complete"] = complete_value
-            
-            # Update the history item
-            last_item["bot"] = bot_response
-            
-            # Save updated history
-            save_hist(hist)
-            
-            log.info("Added %d warnings to conversation history (character limits removed)", len(processed_warnings))
-            return jsonify({"status": "success", "message": f"Stored {len(processed_warnings)} warnings"})
-        else:
-            log.warning("Invalid conversation history format - cannot add warnings")
-            return jsonify({"status": "error", "message": "Invalid conversation history format"})
-            
-    except Exception as e:
-        log.error("store_warnings error: %s", e)
-        error_msg = _truncate_warning(f"Failed to store warnings: {str(e)}")
-        return jsonify({"status": "error", "message": error_msg})
-
-
-def _truncate_warning(warning_msg, max_length=None):
-    """Return warning message without truncation (character limits removed)."""
-    # Character limits removed for conversation history as requested
-    return warning_msg
-
-
-@app.post("/automation/execute-dsl")
-def forward_dsl():
-    payload = request.get_json(force=True)
-    if not payload.get("actions"):
-        return jsonify({"html": "", "warnings": []})
-    try:
-        res_obj = execute_dsl(payload, timeout=120)
-
-        # Update conversation history with the current URL after execution
-        update_last_history_url()
-
-        # Include all warnings without character limits
-        if res_obj and isinstance(res_obj, dict) and "warnings" in res_obj:
-            res_obj["warnings"] = [_truncate_warning(warning) for warning in res_obj["warnings"]]
-
-        return jsonify(res_obj)
-    except requests.Timeout:
-        log.error("forward_dsl timeout")
-        timeout_warning = _truncate_warning("ERROR:auto:Request timeout - The operation took too long to complete")
-        return jsonify({"html": "", "warnings": [timeout_warning]})
-    except Exception as e:
-        log.error("forward_dsl error: %s", e)
-        error_warning = _truncate_warning(f"ERROR:auto:Communication error - {str(e)}")
-        return jsonify({"html": "", "warnings": [error_warning]})
-
-
-@app.route("/automation/stop-request", methods=["GET"])
-def get_stop_request():
-    """Get current stop request from automation server."""
-    try:
-        res = requests.get(_vnc_api_url("/stop-request"), timeout=10)
-        if res.ok:
-            return jsonify(res.json())
-        else:
-            return jsonify(None)
-    except Exception as e:
-        log.error("get_stop_request error: %s", e)
-        return jsonify(None)
-
-
-@app.route("/automation/stop-response", methods=["POST"])
-def post_stop_response():
-    """Forward user response to automation server."""
-    try:
-        data = request.get_json(force=True)
-        res = requests.post(_vnc_api_url("/stop-response"), json=data, timeout=10)
-        if res.ok:
-            return jsonify(res.json())
-        else:
-            return jsonify({"status": "error", "message": "Failed to send response"})
-    except Exception as e:
-        log.error("post_stop_response error: %s", e)
-        return jsonify({"status": "error", "message": str(e)})
-
-
-@app.route("/vnc-source", methods=["GET"])
-def vhtml():
-    return Response(vnc_html(), mimetype="text/plain")
-
-
-@app.route("/screenshot", methods=["GET"])
-def get_screenshot():
-    """VNCサーバーからスクリーンショットを取得してブラウザに返す"""
-    try:
-        res = requests.get(_vnc_api_url("/screenshot"), timeout=300)
-        res.raise_for_status()
-        return Response(res.text, mimetype="text/plain")
-    except Exception as e:
-        log.error("get_screenshot error: %s", e)
-        return Response("", mimetype="text/plain")
-
-
-# --------------- UI エントリポイント ------------------------------
-@app.route("/")
-def outer():
-    return render_template(
-        "layout.html",
-        vnc_url="http://localhost:6901/vnc.html?host=localhost&port=6901&resize=scale",
-        start_url=START_URL,
-        max_steps=MAX_STEPS,
-    )
-
-
-if __name__ == "__main__":
-    import atexit
-    
-    # Setup cleanup on shutdown
-    def cleanup():
-        executor = get_async_executor()
-        executor.shutdown()
-        log.info("Application shutdown cleanup completed")
-    
-    atexit.register(cleanup)
-    
+if __name__ == "__main__":  # pragma: no cover - manual run helper
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -5,3 +5,4 @@ groq
 google-generativeai
 beautifulsoup4
 pydantic>=2.5
+browser-use

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,288 @@
+const state = {
+  activeSession: null,
+  pollTimer: null,
+  renderedSteps: 0,
+};
+
+const chatArea = document.getElementById('chat-area');
+const userInput = document.getElementById('user-input');
+const sendButton = document.getElementById('send-button');
+const stopButton = document.getElementById('stop-button');
+const resetButton = document.getElementById('reset-button');
+const previewImage = document.getElementById('preview-image');
+const previewPlaceholder = document.getElementById('preview-placeholder');
+const previewStatus = document.getElementById('preview-status');
+
+function escapeHtml(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normaliseScreenshot(data) {
+  if (!data || typeof data !== 'string') return null;
+  if (data.startsWith('data:image')) return data;
+  return `data:image/png;base64,${data}`;
+}
+
+function appendMessage(kind, content) {
+  const message = document.createElement('p');
+  if (kind === 'user') {
+    message.classList.add('user-message');
+  } else if (kind === 'system') {
+    message.classList.add('system-message');
+  } else {
+    message.classList.add('bot-message');
+  }
+  message.innerHTML = content;
+  chatArea.appendChild(message);
+  chatArea.scrollTop = chatArea.scrollHeight;
+  return message;
+}
+
+function setExecuting(isExecuting) {
+  if (isExecuting) {
+    sendButton.disabled = true;
+    sendButton.textContent = '実行中...';
+    stopButton.disabled = false;
+  } else {
+    sendButton.disabled = false;
+    sendButton.textContent = '送信';
+    stopButton.disabled = true;
+  }
+}
+
+function updatePreview(step) {
+  const screenshot = normaliseScreenshot(step.screenshot);
+  if (screenshot) {
+    previewImage.src = screenshot;
+    previewImage.style.display = 'block';
+    previewPlaceholder.style.display = 'none';
+  } else {
+    previewImage.style.display = 'none';
+    previewPlaceholder.style.display = 'block';
+  }
+
+  const url = step.url ? escapeHtml(step.url) : '不明';
+  const actionSummary = (step.actions || []).map((action) => {
+    const [name] = Object.keys(action);
+    return name || 'action';
+  });
+
+  const actionsLabel = actionSummary.length
+    ? escapeHtml(actionSummary.join(', '))
+    : '操作情報なし';
+
+  const timestamp = step.timestamp
+    ? new Date(step.timestamp * 1000).toLocaleString()
+    : '';
+
+  previewStatus.innerHTML = `
+    <div><strong>URL:</strong> ${url}</div>
+    <div><strong>アクション:</strong> ${actionsLabel}</div>
+    ${timestamp ? `<div><strong>時刻:</strong> ${escapeHtml(timestamp)}</div>` : ''}
+  `;
+}
+
+function renderActions(actions) {
+  if (!actions || !actions.length) return '<em>アクションなし</em>';
+  const items = actions.map((action) => {
+    const [name, params] = Object.entries(action)[0] || ['操作', {}];
+    const paramText = params
+      ? Object.entries(params)
+          .map(([key, value]) => `${escapeHtml(key)}=${escapeHtml(String(value))}`)
+          .join(', ')
+      : '';
+    return `<li><strong>${escapeHtml(name)}</strong>${paramText ? ` — ${paramText}` : ''}</li>`;
+  });
+  return `<ul>${items.join('')}</ul>`;
+}
+
+function renderStep(step) {
+  const container = document.createElement('div');
+  container.classList.add('bot-message');
+  const title = escapeHtml(step.title || '無題のページ');
+  const thinking = step.thinking ? `<div class="step-card"><strong>思考</strong><div>${escapeHtml(step.thinking)}</div></div>` : '';
+  const nextGoal = step.next_goal
+    ? `<div class="step-card"><strong>次の目標</strong><div>${escapeHtml(step.next_goal)}</div></div>`
+    : '';
+  const memory = step.memory
+    ? `<div class="step-card"><strong>メモリ</strong><div>${escapeHtml(step.memory)}</div></div>`
+    : '';
+  const actions = `<div class="step-card"><strong>実行アクション</strong>${renderActions(step.actions)}</div>`;
+  const url = escapeHtml(step.url || '不明');
+
+  container.innerHTML = `
+    <strong>STEP ${step.index}</strong><br />
+    <span>${title}</span><br />
+    <small>URL: ${url}</small>
+    ${thinking}
+    ${nextGoal}
+    ${memory}
+    ${actions}
+  `;
+
+  chatArea.appendChild(container);
+  chatArea.scrollTop = chatArea.scrollHeight;
+  updatePreview(step);
+}
+
+function clearPolling() {
+  if (state.pollTimer) {
+    clearTimeout(state.pollTimer);
+    state.pollTimer = null;
+  }
+}
+
+async function pollSession() {
+  if (!state.activeSession) return;
+
+  try {
+    const response = await fetch(`/status/${state.activeSession.id}`);
+    if (!response.ok) {
+      throw new Error(`status ${response.status}`);
+    }
+    const data = await response.json();
+    const steps = Array.isArray(data.steps) ? data.steps : [];
+
+    while (state.renderedSteps < steps.length) {
+      renderStep(steps[state.renderedSteps]);
+      state.renderedSteps += 1;
+    }
+
+    const statusText = escapeHtml(data.status || 'unknown');
+    if (data.status === 'completed' || data.status === 'failed' || data.status === 'cancelled') {
+      handleCompletion(data);
+    } else {
+      previewStatus.innerHTML += `<div><strong>ステータス:</strong> ${statusText}</div>`;
+      state.pollTimer = setTimeout(pollSession, 1200);
+    }
+  } catch (err) {
+    appendMessage('system', `❌ 状態取得に失敗しました: ${escapeHtml(err.message || String(err))}`);
+    setExecuting(false);
+    clearPolling();
+    state.activeSession = null;
+  }
+}
+
+function handleCompletion(payload) {
+  const { status, error, result } = payload;
+  clearPolling();
+  setExecuting(false);
+  const finalStatus = status || 'completed';
+
+  if (finalStatus === 'failed') {
+    appendMessage('system', `❌ 実行に失敗しました: ${escapeHtml(error || '原因不明のエラー')}`);
+  } else if (finalStatus === 'cancelled') {
+    appendMessage('system', '⏹ 実行をキャンセルしました。');
+  } else if (result) {
+    const success = result.success !== false;
+    const summary = result.final_result || 'ブラウザ操作が完了しました。';
+    const prefix = success ? '✅' : '⚠️';
+    appendMessage('system', `${prefix} ${escapeHtml(summary)}`);
+    if (Array.isArray(result.errors) && result.errors.length) {
+      const list = result.errors.map((err) => `<li>${escapeHtml(String(err))}</li>`).join('');
+      appendMessage('system', `⚠️ 実行中に警告が発生しました:<ul>${list}</ul>`);
+    }
+    if (Array.isArray(result.urls) && result.urls.length) {
+      previewStatus.innerHTML += `<div><strong>訪問URL:</strong> ${escapeHtml(result.urls[result.urls.length - 1])}</div>`;
+    }
+  } else {
+    appendMessage('system', '✅ ブラウザ操作が完了しました。');
+  }
+
+  state.activeSession = null;
+}
+
+async function startSession(command) {
+  if (!command) return;
+  if (state.activeSession) {
+    appendMessage('system', '⚠️ 現在の実行が完了するまでお待ちください。');
+    return;
+  }
+
+  appendMessage('user', escapeHtml(command));
+  const placeholder = appendMessage('system', 'AI が応答中... <span class="spinner"></span>');
+  setExecuting(true);
+  state.renderedSteps = 0;
+
+  try {
+    const response = await fetch('/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command,
+        model: window.DEFAULT_MODEL || 'gemini',
+        max_steps: window.MAX_STEPS || undefined,
+      }),
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || `server returned ${response.status}`);
+    }
+
+    const data = await response.json();
+    placeholder.remove();
+    state.activeSession = { id: data.session_id };
+    pollSession();
+  } catch (err) {
+    placeholder.remove();
+    appendMessage('system', `❌ 実行開始に失敗しました: ${escapeHtml(err.message || String(err))}`);
+    setExecuting(false);
+  }
+}
+
+async function cancelSession() {
+  if (!state.activeSession) return;
+  try {
+    await fetch(`/cancel/${state.activeSession.id}`, { method: 'POST' });
+    appendMessage('system', '⏹ 停止リクエストを送信しました。');
+  } catch (err) {
+    appendMessage('system', `⚠️ 停止リクエストに失敗しました: ${escapeHtml(err.message || String(err))}`);
+  }
+}
+
+async function resetHistory() {
+  try {
+    const response = await fetch('/reset', { method: 'POST' });
+    const data = await response.json();
+    chatArea.innerHTML = '<p class="bot-message">こんにちは！ご質問はありますか？</p>';
+    appendMessage('system', escapeHtml(data.message || '会話履歴がリセットされました。'));
+  } catch (err) {
+    appendMessage('system', `⚠️ リセットに失敗しました: ${escapeHtml(err.message || String(err))}`);
+  }
+}
+
+sendButton.addEventListener('click', () => {
+  const command = userInput.value.trim();
+  if (!command) return;
+  userInput.value = '';
+  startSession(command);
+});
+
+userInput.addEventListener('keydown', (event) => {
+  if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+    event.preventDefault();
+    sendButton.click();
+  }
+});
+
+stopButton.addEventListener('click', () => {
+  cancelSession();
+});
+
+resetButton.addEventListener('click', () => {
+  if (state.activeSession) {
+    appendMessage('system', '⚠️ 実行中はリセットできません。まず停止してください。');
+    return;
+  }
+  resetHistory();
+});
+
+stopButton.disabled = true;
+userInput.focus();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,194 +1,275 @@
-/* ベーススタイル */
 body {
-    background-color: #f0f2f5;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    margin: 0;
-    padding: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  background: #f1f3f6;
+  color: #1f2933;
 }
 
-/* 新しいレイアウトのチャットパネルスタイル */
-#chat-panel {
-    background: #fff;
-    box-shadow: 2px 0px 8px rgba(0, 0, 0, 0.1);
-    /* Responsive width - reduced default for better VNC visibility */
-    width: 420px;
-    min-width: 300px; /* Ensure chat remains usable */
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f1f5f9 0%, #eef2ff 100%);
 }
 
-#chat-area {
-    flex-grow: 1;
-    padding: 15px;
-    overflow-y: auto;
-    background: #f7f7f7;
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  width: 420px;
+  min-width: 320px;
+  background: #ffffff;
+  border-right: 1px solid #e5e7eb;
+  box-shadow: 2px 0 12px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(4px);
 }
 
-#chat-area p {
-    margin: 10px 0;
-    padding: 10px;
-    border-radius: 12px;
-    max-width: 80%;
-    word-wrap: break-word;
-    font-size: 14px;
+.chat-header {
+  padding: 18px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #ffffff;
+  background: linear-gradient(135deg, #6366f1, #2563eb);
+}
+
+.chat-area {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
+  background: #f7f8fb;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-area p {
+  margin: 8px 0;
+  padding: 12px 14px;
+  border-radius: 16px;
+  max-width: 90%;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
 }
 
 .user-message {
-    background: #e0f7fa;
-    align-self: flex-end;
-    margin-left: auto;
+  align-self: flex-end;
+  background: #daf2ff;
+  border: 1px solid rgba(59, 130, 246, 0.35);
 }
 
 .bot-message {
-    background: #e8eaf6;
-    align-self: flex-start;
+  align-self: flex-start;
+  background: #e8eaf6;
+  border: 1px solid rgba(99, 102, 241, 0.2);
 }
 
-#input-area button:hover {
-    background: linear-gradient(135deg, #2575fc, #6a11cb);
+.system-message {
+  align-self: center;
+  background: #fff8e1;
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  color: #7c6513;
 }
 
-/* スピナー */
-.spinner {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    border: 2px solid rgba(0, 0, 0, 0.2);
-    border-top: 2px solid #4facfe;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-    margin-left: 8px;
+.input-area {
+  padding: 16px;
+  background: #ffffff;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  gap: 12px;
+}
+
+.input-wrapper {
+  flex: 1;
+}
+
+.chat-input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 14px;
+  resize: vertical;
+  min-height: 70px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.input-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.primary-action {
+  background: linear-gradient(135deg, #6366f1, #2563eb);
+  color: #ffffff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(99, 102, 241, 0.25);
+}
+
+.secondary-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.danger-action {
+  background: #dc3545;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  padding: 7px 14px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.danger-action:hover {
+  background: #c82333;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed !important;
+  box-shadow: none !important;
+}
+
+.preview-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #0f172a;
+  color: #f8fafc;
+  position: relative;
+}
+
+.preview-header {
+  padding: 18px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.8), rgba(14, 165, 233, 0.8));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.preview-body {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.08), transparent 60%);
+  overflow: hidden;
+}
+
+#preview-image {
+  max-width: 100%;
+  max-height: 100%;
+  display: none;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  border-radius: 12px;
+}
+
+.preview-placeholder {
+  position: absolute;
+  padding: 0 24px;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.preview-meta {
+  padding: 16px 20px;
+  background: rgba(15, 23, 42, 0.85);
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  font-size: 14px;
+  min-height: 88px;
+}
+
+.preview-meta strong {
+  color: #38bdf8;
+}
+
+.step-card {
+  border-left: 3px solid #6366f1;
+  padding: 10px 12px;
+  margin-top: 10px;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.step-card strong {
+  color: #4338ca;
+}
+
+.spinner,
+.inline-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top: 2px solid #38bdf8;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.inline-spinner {
+  margin-left: 6px;
 }
 
 @keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
-.system-message {                /* 追加 */
-    background: #fff3cd;         /* 追加 */
-    color: #856404;              /* 追加 */
-    align-self: center;          /* 追加 */
+@media (max-width: 980px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .chat-panel {
+    width: 100%;
+    min-width: unset;
+    height: 45vh;
+  }
+
+  .preview-panel {
+    height: 55vh;
+  }
 }
 
+@media (max-width: 600px) {
+  .chat-area p {
+    max-width: 100%;
+  }
 
+  .input-actions {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 
+  .secondary-actions {
+    gap: 6px;
+  }
 
-
-/* Warning styles */
-.warnings-container {
-    font-family: 'Courier New', monospace;
-    font-size: 12px;
-    line-height: 1.4;
+  .chat-input {
+    min-height: 60px;
+  }
 }
-
-.warnings-container::-webkit-scrollbar {
-    width: 6px;
-}
-
-.warnings-container::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 3px;
-}
-
-.warnings-container::-webkit-scrollbar-thumb {
-    background: #ffc107;
-    border-radius: 3px;
-}
-
-/* Disabled button styles */
-button:disabled {
-    opacity: 0.6;
-    cursor: not-allowed !important;
-    background: #6c757d !important;
-    transform: none !important;
-}
-
-/* Enhanced spinner for inline usage */
-.inline-spinner {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border: 2px solid #f3f3f3;
-    border-top: 2px solid #3498db;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-    margin-left: 4px;
-}
-
-/* Progress indicator */
-.execution-progress {
-    margin: 8px 0;
-    padding: 8px 12px;
-    background: linear-gradient(135deg, #e3f2fd, #bbdefb);
-    border-left: 4px solid #2196f3;
-    border-radius: 6px;
-    font-size: 12px;
-    color: #1565c0;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-/* VNC section - ensure it fills available space properly */
-#vnc-section {
-    min-width: 400px; /* Reduced min-width to prevent horizontal scroll issues */
-    overflow: hidden; /* Prevent overflow, let iframe scale */
-}
-
-/* VNC iframe responsive scaling */
-#vnc_frame {
-    min-width: 100%;
-    min-height: 100%;
-    object-fit: contain; /* Ensure iframe content scales properly */
-}
-
-/* Responsive breakpoints for chat panel */
-@media (max-width: 1200px) {
-    #chat-panel {
-        width: 350px;
-    }
-}
-
-@media (max-width: 1000px) {
-    #chat-panel {
-        width: 320px;
-    }
-}
-
-@media (max-width: 900px) {
-    /* Switch to vertical layout earlier to ensure VNC visibility */
-    main {
-        flex-direction: column !important;
-    }
-    
-    #chat-panel {
-        width: 100% !important;
-        height: 35vh;
-        border-right: none !important;
-        border-bottom: 1px solid #ddd;
-    }
-    
-    #vnc-section {
-        height: 65vh;
-        min-width: unset; /* Remove min-width constraint in vertical layout */
-        overflow: visible; /* Allow proper scaling in vertical layout */
-    }
-}
-
-@media (max-width: 768px) {
-    #chat-panel {
-        height: 40vh;
-    }
-    
-    #vnc-section {
-        height: 60vh;
-    }
-}
-
-
-
-
-

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -1,68 +1,55 @@
-<!DOCTYPE html>
-<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}AI Agent + VNC{% endblock %}</title>
+  <title>{% block title %}AI Browser Agent{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-
-
-  <!-- ===== メインコンテンツ: 左チャット + 右VNC ===== -->
-  <main style="display:flex;flex-direction:row;height:100vh;">
-    <!-- 左側: チャット欄 -->
-    <div id="chat-panel" style="display:flex;flex-direction:column;border-right:1px solid #ddd;">
-      <div id="chat-header" style="background:linear-gradient(135deg, #6a11cb, #2575fc);padding:15px;color:white;font-weight:bold;">
+  <main id="app" class="app-shell">
+    <section id="chat-panel" class="chat-panel">
+      <header id="chat-header" class="chat-header">
         <span>チャット</span>
-      </div>
-      <div id="chat-area" style="flex:1;padding:15px;overflow-y:auto;background:#f7f7f7;">
+      </header>
+      <div id="chat-area" class="chat-area">
         <p class="bot-message">こんにちは！ご質問はありますか？</p>
       </div>
-      <div id="input-area" style="background:#f9f9f9;padding:15px;display:flex;gap:10px;align-items:center;">
-        <div style="flex:1;">
-          <textarea id="user-input" rows="3" placeholder="ここに入力..." style="width:100%;border:1px solid #ddd;border-radius:8px;padding:10px;font-size:14px;resize:vertical;min-height:60px;"></textarea>
+      <footer id="input-area" class="input-area">
+        <div class="input-wrapper">
+          <textarea id="user-input" rows="3" placeholder="ここに入力..." class="chat-input"></textarea>
         </div>
-        <div style="display:flex;flex-direction:column;gap:8px;">
-          <button style="background:linear-gradient(135deg, #6a11cb, #2575fc);color:white;border:none;border-radius:8px;padding:10px 20px;font-weight:bold;cursor:pointer;">送信</button>
-          <div style="display:flex;gap:5px;">
-            <button id="stop-button" style="background:#dc3545;color:white;border:none;border-radius:6px;padding:6px 12px;font-size:12px;cursor:pointer;">停止</button>
-            <button id="pause-button" style="background:#ffc107;color:#212529;border:none;border-radius:6px;padding:6px 12px;font-size:12px;cursor:pointer;">一時停止</button>
-            <button id="resume-button" style="display:none;background:#28a745;color:white;border:none;border-radius:6px;padding:6px 12px;font-size:12px;cursor:pointer;">続行</button>
-            <button id="reset-button" style="background:#dc3545;color:white;border:none;border-radius:6px;padding:6px 12px;font-size:12px;cursor:pointer;">リセット</button>
+        <div class="input-actions">
+          <button id="send-button" class="primary-action">送信</button>
+          <div class="secondary-actions">
+            <button id="stop-button" class="danger-action">停止</button>
+            <button id="reset-button" class="danger-action">リセット</button>
           </div>
         </div>
+      </footer>
+    </section>
+
+    <section id="preview-panel" class="preview-panel">
+      <header class="preview-header">
+        <span>最新スクリーンショット</span>
+      </header>
+      <div id="preview-body" class="preview-body">
+        <img id="preview-image" alt="最新のブラウザ状態" />
+        <div id="preview-placeholder" class="preview-placeholder">
+          実行中の操作がここに表示されます。
+        </div>
       </div>
-    </div>
-
-    <!-- 右側: VNC iframe -->
-    <div id="vnc-section" style="flex:1;display:flex;flex-direction:column;">
-      <iframe id="vnc_frame" src="{{ vnc_url }}" style="width:100%;height:100%;border:none;"></iframe>
-    </div>
-
-
+      <div id="preview-meta" class="preview-meta">
+        <div id="preview-status">実行の進捗はここに表示されます。</div>
+      </div>
+    </section>
 
     {% block content %}{% endblock %}
   </main>
 
-  <div id="hidden-browser-executor" style="display:none;">
-    <textarea id="nlCommand"></textarea>
-    <button id="executeButton">実行</button>
-    <pre id="logOutput"></pre>
-  </div>
-
-
-
-  <!-- JavaScript -->
   <script>
-    window.START_URL  = "{{ start_url }}";
+    window.DEFAULT_MODEL = "{{ default_model }}";
     window.MAX_STEPS = {{ max_steps }};
   </script>
-  <script src="/static/html2canvas.min.js"></script>
-  <script src="/static/common_executor.js"></script>
-  <script src="/static/browser_executor.js"></script>
-  <script src="/static/chat_integration.js"></script>
-  <script src="/static/script.js"></script>
+  <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a browser-use session manager that wraps the agent lifecycle and history capture
- replace the Flask automation API with browser-use backed execution and new status/cancel endpoints
- rebuild the front-end to poll the new API, render step details and screenshots, and refresh styling

## Testing
- python -m compileall agent/browser_use_runner.py web/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ca1797c8832098fba9865289822c