### PR TITLE
Fix Dockerfile apt-get command after heredoc

### DIFF
--- a/vnc/Dockerfile
+++ b/vnc/Dockerfile
@@ -71,7 +71,7 @@ if sources_dir.exists():
     for sources_file in sources_dir.glob("*.sources"):
         update_deb822(sources_file)
 PY
-    apt-get update && apt-get install -y --no-install-recommends \
+    && apt-get update && apt-get install -y --no-install-recommends \
       chromium xvfb x11vnc websockify novnc supervisor \
       wget curl ca-certificates gnupg \
       libnss3 libatk-bridge2.0-0 libu2f-udev libdrm2 \


### PR DESCRIPTION
## Summary
- chain the apt-get invocation to the heredoc RUN instruction in the VNC Dockerfile
- resolve the Dockerfile parse error encountered during docker compose builds

## Testing
- docker compose up --build *(fails: docker command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f2cd9788832094f056aac1e82238