### PR TITLE
Handle missing uvx by patching browser_use to use Playwright

### DIFF
--- a/agent/browser/patches.py
+++ b/agent/browser/patches.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Runtime patches that smooth integration with ``browser_use``."""
+
+import asyncio
+import logging
+import shutil
+import sys
+from typing import Iterable
+
+_patch_applied = False
+
+
+async def _run_subprocess(command: Iterable[str]) -> tuple[int, bytes, bytes]:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=120.0)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+        raise
+    return process.returncode, stdout, stderr
+
+
+def apply_browser_use_patches(logger: logging.Logger | None = None) -> None:
+    global _patch_applied
+    if _patch_applied:
+        return
+
+    log = logger or logging.getLogger(__name__)
+    try:
+        from browser_use.browser.watchdogs.local_browser_watchdog import (  # type: ignore import
+            LocalBrowserWatchdog,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("Could not import LocalBrowserWatchdog for patching: %s", exc)
+        return
+
+    if getattr(LocalBrowserWatchdog._install_browser_with_playwright, "_agent_patch", False):  # type: ignore[attr-defined]
+        _patch_applied = True
+        return
+
+    async def _install_browser_with_playwright(self):  # type: ignore[override]
+        existing_path = self._find_installed_browser_path()
+        if existing_path:
+            return existing_path
+
+        commands = []
+        playwright_cli = shutil.which("playwright")
+        if playwright_cli:
+            commands.append([playwright_cli, "install", "chrome", "--with-deps"])
+            commands.append([playwright_cli, "install", "chrome"])
+        commands.append([sys.executable, "-m", "playwright", "install", "chrome", "--with-deps"])
+        commands.append([sys.executable, "-m", "playwright", "install", "chrome"])
+
+        last_stdout = b""
+        last_stderr = b""
+        attempted: list[str] = []
+        for command in commands:
+            cmd_display = " ".join(command)
+            if cmd_display in attempted:
+                continue
+            attempted.append(cmd_display)
+            try:
+                returncode, stdout, stderr = await _run_subprocess(command)
+            except FileNotFoundError:
+                self.logger.debug("Playwright helper not found for command: %s", cmd_display)
+                continue
+            except asyncio.TimeoutError:
+                self.logger.warning(
+                    "Timed out waiting for Playwright command: %s", cmd_display
+                )
+                continue
+
+            if returncode == 0:
+                browser_path = self._find_installed_browser_path()
+                if browser_path:
+                    self.logger.debug(
+                        "Playwright install succeeded with command: %s", cmd_display
+                    )
+                    return browser_path
+            last_stdout, last_stderr = stdout, stderr
+
+        raise RuntimeError(
+            "Failed to install browser using Playwright commands. "
+            f"Tried: {attempted}. "
+            f"stdout={last_stdout.decode(errors='ignore')} stderr={last_stderr.decode(errors='ignore')}"
+        )
+
+    _install_browser_with_playwright._agent_patch = True  # type: ignore[attr-defined]
+    LocalBrowserWatchdog._install_browser_with_playwright = _install_browser_with_playwright
+    _patch_applied = True
+
+    log.info("Patched LocalBrowserWatchdog to use python -m playwright when uvx is unavailable")

--- a/agent/browser_use_runner.py
+++ b/agent/browser_use_runner.py
@@ -17,9 +17,11 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.llm.google.chat import ChatGoogle
 from browser_use.llm.groq.chat import ChatGroq
 
+from agent.browser.patches import apply_browser_use_patches
 from agent.utils.history import append_history_entry
 
 log = logging.getLogger(__name__)
+apply_browser_use_patches(log)
 
 
 def _now() -> float:

--- a/web/app.py
+++ b/web/app.py
@@ -10,10 +10,13 @@ from flask import Flask, jsonify, render_template, request, send_from_directory
 from agent.browser_use_runner import get_browser_use_manager
 from agent.utils import history as history_utils
 from agent.utils.history import load_hist, save_hist
+from vnc.dependency_check import ensure_component_dependencies
 
 app = Flask(__name__)
 log = logging.getLogger("agent")
 log.setLevel(logging.INFO)
+
+ensure_component_dependencies("web", logger=log)
 
 MAX_STEPS = max(1, int(os.getenv("MAX_STEPS", "15")))
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gemini")

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -6,3 +6,4 @@ google-generativeai
 beautifulsoup4
 pydantic>=2.5
 browser-use
+playwright==1.44.0


### PR DESCRIPTION
## Summary
- add a runtime patch that makes browser_use fall back to python -m playwright when the uvx CLI is unavailable
- apply the patch during browser_use runner initialisation and assert dependencies at web-app start-up
- declare the Playwright dependency for the web service so installs pull in the required CLI

## Testing
- python -m vnc.dependency_check --component web

------
https://chatgpt.com/codex/tasks/task_e_68d0f59f14cc8320827f6a5a598d451c