### PR TITLE
Ensure Playwright browser availability and align step limits

### DIFF
--- a/agent/controller/prompt.py
+++ b/agent/controller/prompt.py
@@ -5,7 +5,7 @@ from ..utils.html import strip_html
 from ..browser.dom import DOMElementNode
 
 log = logging.getLogger("controller")
-MAX_STEPS = int(os.getenv("MAX_STEPS", "10"))
+MAX_STEPS = max(1, int(os.getenv("MAX_STEPS", "15")))
 
 
 def _extract_recent_warnings(hist, max_warnings=5):

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.12-slim
+FROM mcr.microsoft.com/playwright/python:v1.44.0-jammy
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/web/static/browser_executor.js
+++ b/web/static/browser_executor.js
@@ -824,7 +824,10 @@ async function executeTask(cmd, model = "gemini", placeholder = null) {
   stopController = new AbortController();
   window.stopController = stopController;
 
-  const MAX_STEPS = typeof window.MAX_STEPS === "number" ? window.MAX_STEPS : 10;
+  const MAX_STEPS =
+    typeof window.MAX_STEPS === "number" && Number.isFinite(window.MAX_STEPS)
+      ? window.MAX_STEPS
+      : 15;
   let stepCount = 0;
   let keepLoop  = true;
   let firstIter = true;


### PR DESCRIPTION
## Summary
- switch the web service Dockerfile to the official Playwright base image so the required browser binaries are pre-installed
- align MAX_STEPS defaults in the controller prompt and browser executor fallback to match the Flask configuration

## Testing
- python -m vnc.dependency_check --component web
- python -m vnc.dependency_check --component vnc

------
https://chatgpt.com/codex/tasks/task_e_68d0f87810f883209544c53ae2e4258b