### PR TITLE
Update web Docker image to Python 3.11+

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,9 +1,23 @@
-FROM mcr.microsoft.com/playwright/python:v1.44.0-jammy
+FROM mcr.microsoft.com/playwright/python:v1.49.1-jammy
+
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
+# Ensure the base image provides a new enough interpreter for browser-use
+RUN python - <<'PY'
+import sys
+minimum = (3, 11)
+if sys.version_info < minimum:
+    raise SystemExit(
+        f"Python {minimum[0]}.{minimum[1]}+ is required, found {sys.version}"
+    )
+PY
+
 COPY requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir -r requirements.txt \
+    && python -m playwright install chromium
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- switch the web service Docker image to Playwright Python v1.49.1 (jammy) so that Python meets browser-use's >=3.11 requirement and enable unbuffered output
- add a build-time interpreter version assertion along with upgrading pip before installing project requirements
- pre-install Playwright's Chromium browser assets after dependency installation to keep the runtime aligned with the pinned Playwright version

## Testing
- python -m compileall agent web
- docker compose build web *(fails: docker client unavailable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb4f2b348320af992afa3714b090