### PR TITLE
Fix Docker build by installing pip via apt

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,12 +12,12 @@ RUN apt-get update \
         python3.11 \
         python3.11-distutils \
         python3.11-venv \
+        python3-pip \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 2 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2 \
-    && python -m ensurepip --upgrade
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
 
 # Ensure the base image provides a new enough interpreter for browser-use
 RUN python - <<'PY'


### PR DESCRIPTION
## Summary
- install the python3-pip package so the Python 3.11 interpreter has pip available without relying on ensurepip
- drop the explicit ensurepip invocation that fails on Debian-based images where the module is disabled

## Testing
- docker compose build web *(fails: docker command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10070840c8320b90b57ac26ea80e3