### PR TITLE
Ensure dashboard fits viewport and improve step cards

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,14 +1,22 @@
+html {
+  height: 100%;
+}
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   margin: 0;
   background: #f1f3f6;
   color: #1f2933;
+  height: 100%;
+  overflow: hidden;
 }
 
 .app-shell {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
+  width: 100%;
   background: linear-gradient(135deg, #f1f5f9 0%, #eef2ff 100%);
+  overflow: hidden;
 }
 
 .chat-panel {
@@ -20,6 +28,10 @@ body {
   border-right: 1px solid #e5e7eb;
   box-shadow: 2px 0 12px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(4px);
+  height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
+  min-height: 0;
 }
 
 .chat-header {
@@ -34,12 +46,18 @@ body {
   flex: 1;
   padding: 16px;
   overflow-y: auto;
+  overflow-x: hidden;
   background: #f7f8fb;
   display: flex;
   flex-direction: column;
+  gap: 10px;
+  min-height: 0;
 }
 
-.chat-area p {
+.chat-area p,
+.chat-area .bot-message,
+.chat-area .system-message,
+.chat-area .user-message {
   margin: 8px 0;
   padding: 12px 14px;
   border-radius: 16px;
@@ -47,6 +65,8 @@ body {
   font-size: 14px;
   line-height: 1.5;
   box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .user-message {
@@ -152,6 +172,10 @@ button:disabled {
   background: #0f172a;
   color: #f8fafc;
   position: relative;
+  height: 100vh;
+  max-height: 100vh;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .preview-header {
@@ -170,6 +194,7 @@ button:disabled {
   justify-content: center;
   background: radial-gradient(circle at top, rgba(59, 130, 246, 0.08), transparent 60%);
   overflow: hidden;
+  min-height: 0;
 }
 
 #preview-image {
@@ -195,24 +220,144 @@ button:disabled {
   border-top: 1px solid rgba(148, 163, 184, 0.15);
   font-size: 14px;
   min-height: 88px;
+  max-height: 35vh;
+  overflow-y: auto;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .preview-meta strong {
   color: #38bdf8;
 }
 
-.step-card {
-  border-left: 3px solid #6366f1;
-  padding: 10px 12px;
-  margin-top: 10px;
-  background: rgba(99, 102, 241, 0.08);
-  border-radius: 10px;
-  font-size: 13px;
-  line-height: 1.5;
+.step-message {
+  padding: 16px;
+  border-radius: 18px;
+  background: #eef2ff;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.1), 0 4px 12px rgba(79, 70, 229, 0.12);
+  max-width: 100%;
+  border: none;
 }
 
-.step-card strong {
+.step-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #3730a3;
+  background: #c7d2fe;
+  padding: 4px 12px;
+  border-radius: 999px;
+}
+
+.step-title {
+  font-weight: 600;
+  font-size: 15px;
+  color: #1f2933;
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.step-meta-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.step-meta-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #4f46e5;
+  text-transform: uppercase;
+}
+
+.step-url {
+  font-size: 13px;
+  color: #1d4ed8;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  flex: 1;
+  min-width: 0;
+}
+
+.step-url:hover,
+.step-url:focus {
+  text-decoration: underline;
+}
+
+.step-section {
+  margin-top: 14px;
+}
+
+.step-section-label {
+  font-size: 13px;
+  font-weight: 700;
   color: #4338ca;
+  margin-bottom: 6px;
+}
+
+.step-card {
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.08);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.step-section-body {
+  display: block;
+}
+
+.step-action-list {
+  margin: 0;
+  padding-left: 1.2em;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.step-action-list li {
+  list-style: disc;
+  font-size: 13px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.step-action-list .action-name {
+  font-weight: 600;
+  color: #312e81;
+  margin-right: 6px;
+}
+
+.step-action-list .action-params {
+  color: #334155;
+}
+
+.step-action-empty {
+  list-style: none;
+  padding-left: 0;
+  color: #64748b;
+  font-style: italic;
 }
 
 .spinner,
@@ -242,16 +387,23 @@ button:disabled {
 @media (max-width: 980px) {
   .app-shell {
     flex-direction: column;
+    height: auto;
   }
 
   .chat-panel {
     width: 100%;
     min-width: unset;
     height: 45vh;
+    max-height: unset;
   }
 
   .preview-panel {
     height: 55vh;
+    max-height: unset;
+  }
+
+  body {
+    overflow: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- Constrain the chat and preview panels to the viewport with internal scrolling so the dashboard no longer grows beyond the screen.
- Render automation steps as structured cards with wrapped URLs, action lists, and improved metadata presentation.
- Refresh styling for long messages and preview metadata to prevent horizontal scrolling while keeping the layout responsive.

## Testing
- PYTHONPATH=/workspace/web_agent01 python app.py

------
https://chatgpt.com/codex/tasks/task_e_68d1040d8758832084478771dca5400e