### PR TITLE
Allow remote IPs for Chromium debugging

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,14 @@
+# Setup notes
+
+## Chromium remote debugging configuration
+
+The VNC image launches Chromium through [`vnc/scripts/start-chromium.sh`](vnc/scripts/start-chromium.sh)
+with remote debugging exposed on port 9222. To allow other containers (for
+example the web UI) to connect, the script must keep both of the following
+flags enabled and in sync with any documented allow-lists:
+
+- `--remote-allow-origins="*"`
+- `--remote-allow-ips="*"`
+
+If you need to tighten the allow-list, update the script and these notes
+together so the configuration remains accurate.

--- a/vnc/scripts/start-chromium.sh
+++ b/vnc/scripts/start-chromium.sh
@@ -27,11 +27,12 @@ URL="${START_URL:-https://www.yahoo.co.jp/}"
 
 if ! pgrep -f "--remote-debugging-port=9222" >/dev/null; then
   echo "[chromium] launching chromium..."
-  # ``--remote-allow-origins=*`` is required so other containers (for example the
-  # web UI that drives the LLM) can attach to the CDP endpoint exposed on 9222.
+  # ``--remote-allow-origins=*`` and ``--remote-allow-ips=*`` are required so
+  # other containers (for example the web UI that drives the LLM) can attach to
+  # the CDP endpoint exposed on 9222.
   chromium --no-sandbox --disable-dev-shm-usage \
            --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 \
-           --remote-allow-origins="*" \
+           --remote-allow-origins="*" --remote-allow-ips="*" \
            --window-size=1280,800 "$URL" &
 fi
 


### PR DESCRIPTION
## Summary
- allow Chromium's DevTools endpoint to accept remote callers by adding `--remote-allow-ips=*`
- document the remote debugging flags in the setup notes so future updates stay in sync

## Testing
- `docker compose build vnc` *(fails: `docker` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d345cda52c8320bd92f9b249eb6e62