### PR TITLE
Remove preview metadata panel from browser view

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -26,7 +26,6 @@ const stopButton = document.getElementById('stop-button');
 const resetButton = document.getElementById('reset-button');
 const previewImage = document.getElementById('preview-image');
 const previewPlaceholder = document.getElementById('preview-placeholder');
-const previewStatus = document.getElementById('preview-status');
 const screenshotContainer = document.getElementById('screenshot-container');
 const liveBrowserContainer = document.getElementById('live-browser-container');
 const liveBrowserSurface = document.getElementById('live-browser-canvas');
@@ -559,25 +558,6 @@ function updatePreview(step) {
     previewPlaceholder.style.display = 'block';
   }
 
-  const url = step.url ? escapeHtml(step.url) : '不明';
-  const actionSummary = (step.actions || []).map((action) => {
-    const [name] = Object.keys(action);
-    return name || 'action';
-  });
-
-  const actionsLabel = actionSummary.length
-    ? escapeHtml(actionSummary.join(', '))
-    : '操作情報なし';
-
-  const timestamp = step.timestamp
-    ? new Date(step.timestamp * 1000).toLocaleString()
-    : '';
-
-  previewStatus.innerHTML = `
-    <div><strong>URL:</strong> ${url}</div>
-    <div><strong>アクション:</strong> ${actionsLabel}</div>
-    ${timestamp ? `<div><strong>時刻:</strong> ${escapeHtml(timestamp)}</div>` : ''}
-  `;
 }
 
 function renderActions(actions) {
@@ -796,11 +776,9 @@ async function pollSession() {
       state.renderedSteps += 1;
     }
 
-    const statusText = escapeHtml(data.status || 'unknown');
     if (data.status === 'completed' || data.status === 'failed' || data.status === 'cancelled') {
       handleCompletion(data);
     } else {
-      previewStatus.innerHTML += `<div><strong>ステータス:</strong> ${statusText}</div>`;
       state.pollTimer = setTimeout(pollSession, 1200);
     }
   } catch (err) {
@@ -846,9 +824,6 @@ function handleCompletion(payload) {
         state.displayedWarnings.add(text);
         appendMessage('system', `⚠️ ${escapeHtml(text)}`);
       }
-    }
-    if (Array.isArray(result.urls) && result.urls.length) {
-      previewStatus.innerHTML += `<div><strong>訪問URL:</strong> ${escapeHtml(result.urls[result.urls.length - 1])}</div>`;
     }
   } else {
     appendMessage('system', '✅ ブラウザ操作が完了しました。');

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -363,22 +363,6 @@ button:disabled {
   }
 }
 
-.preview-meta {
-  padding: 16px 20px;
-  background: rgba(15, 23, 42, 0.85);
-  border-top: 1px solid rgba(148, 163, 184, 0.15);
-  font-size: 14px;
-  min-height: 88px;
-  max-height: 35vh;
-  overflow-y: auto;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-}
-
-.preview-meta strong {
-  color: #38bdf8;
-}
-
 .step-message {
   padding: 16px;
   border-radius: 18px;

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -67,9 +67,6 @@
           ></div>
         </div>
       </div>
-      <div id="preview-meta" class="preview-meta">
-        <div id="preview-status">実行の進捗はここに表示されます。</div>
-      </div>
     </section>
 
     {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- remove the preview metadata section from the browser view layout
- delete the associated styles and JavaScript status updates that populated that panel

## Testing
- manual: PYTHONPATH=/workspace/web_agent01 python web/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d35ed222f88320a264021c6015845c