### PR TITLE
Add instruction endpoint to automation server

### DIFF
--- a/tests/test_automation_server.py
+++ b/tests/test_automation_server.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from vnc import automation_server
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch, status: str, captured: dict[str, str]):
+    class DummyManager:
+        def add_instruction(self, session_id: str, instruction: str) -> str:
+            captured["session_id"] = session_id
+            captured["instruction"] = instruction
+            return status
+
+    manager = DummyManager()
+    monkeypatch.setattr(automation_server, "_get_browser_use_manager", lambda: manager)
+    return automation_server.app.test_client()
+
+
+def test_add_instruction_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+    client = _make_client(monkeypatch, "accepted", captured)
+
+    response = client.post(
+        "/browser-use/session/demo/instruction",
+        json={"instruction": "次の作業を続けて"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "accepted"}
+    assert captured == {"session_id": "demo", "instruction": "次の作業を続けて"}
+
+
+@pytest.mark.parametrize(
+    "status, expected_code, expected_payload",
+    [
+        ("not_found", 404, {"error": "session not found"}),
+        (
+            "not_running",
+            409,
+            {
+                "error": "セッションは既に完了または停止しています。",
+                "status": "not_running",
+            },
+        ),
+        ("invalid", 400, {"error": "instruction empty"}),
+    ],
+)
+def test_add_instruction_error_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    expected_code: int,
+    expected_payload: dict[str, str],
+) -> None:
+    captured: dict[str, str] = {}
+    client = _make_client(monkeypatch, status, captured)
+
+    response = client.post(
+        "/browser-use/session/demo/instruction",
+        json={"command": "  フォールバック  "},
+    )
+
+    assert response.status_code == expected_code
+    assert response.get_json() == expected_payload
+    assert captured == {"session_id": "demo", "instruction": "フォールバック"}
+
+
+def test_add_instruction_rejects_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+    client = _make_client(monkeypatch, "accepted", captured)
+
+    response = client.post(
+        "/browser-use/session/demo/instruction",
+        json={"instruction": "   "},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "instruction empty"}
+    assert captured == {}


### PR DESCRIPTION
## Summary
- add a /browser-use/session/<id>/instruction endpoint to the automation server so follow-up commands are forwarded to the running session
- mirror the local web app status handling for missing, finished, or invalid sessions
- cover the new API path with unit tests exercising success and error responses

## Testing
- pytest tests/test_automation_server.py tests/test_web_app.py tests/test_browser_use_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d578165083208466e28bd27547f5